### PR TITLE
mt-config: Add monorepo-root for apple/master

### DIFF
--- a/mt-config/apple.mt-config
+++ b/mt-config/apple.mt-config
@@ -54,6 +54,7 @@ dir github/llvm.org/master lldb              split/llvm.org/lldb/master
 # branch depends on the 'swift' repo.  See swift/master-next for LLDB's
 # upstream-with-swift branch.
 generate branch apple/master
+dir apple/master -                 split/apple/root/apple/master
 dir apple/master clang             split/apple/clang/upstream-with-swift
 dir apple/master clang-tools-extra split/apple/clang-tools-extra/upstream-with-swift
 dir apple/master compiler-rt       split/apple/compiler-rt/upstream-with-swift


### PR DESCRIPTION
This will add out of tree changes for the monorepo-root to apple/master.  It doesn't make sense to merge this until we actually have out-of-tree changes because that would prevent us getting changes from upstream.