### PR TITLE
mt-config: Add monorepo-root for apple/stable/20190104

### DIFF
--- a/mt-config/apple.mt-config
+++ b/mt-config/apple.mt-config
@@ -144,6 +144,7 @@ dir    swift/swift-5.0-branch lldb split/apple/lldb/swift-5.0-branch
 
 # Generate apple/stable/20190104 from swift-5.1-branch, skipping LLDB at first.
 generate branch apple/stable/20190104
+dir apple/stable/20190104 -                 split/apple/root/apple/stable/20190104
 dir apple/stable/20190104 clang             split/apple/clang/swift-5.1-branch
 dir apple/stable/20190104 clang-tools-extra split/apple/clang-tools-extra/swift-5.1-branch
 dir apple/stable/20190104 compiler-rt       split/apple/compiler-rt/swift-5.1-branch


### PR DESCRIPTION
This will add out of tree changes for the monorepo-root to apple/stable/20190104. Since there's no upstream for this branch, it doesn't hurt to merge this right now.

If we need different content in swift/master we can add another branch and add it to the config, but as long as the content matches the `repeat` directives will take care of propagating from apple/stable/20190104.