### PR TITLE
split2mono: Prevent 8bf1494af87f from being identified as r354826

### DIFF
--- a/src/commit_interleaver.h
+++ b/src/commit_interleaver.h
@@ -376,6 +376,10 @@ int translation_queue::parse_source(const char *&current, const char *end) {
     //
     // TODO: add a testcase where a split repository history has forked with
     // upstream LLVM and no splitref was added by mt-config.
+    //
+    // FIXME: is there a way to avoid this logic?  That might allow us to
+    // remove the blacklist in the transitive call to
+    // git_cache::compute_rev_with_metadata.
     sha1_ref mono;
     if (!cache.compute_mono(commit, mono)) {
       assert(mono);

--- a/src/git_cache.h
+++ b/src/git_cache.h
@@ -364,6 +364,24 @@ int git_cache::compute_rev_with_metadata(sha1_ref commit, int &rev,
     }
   }
 
+  // Manually blacklist cherry-picks that don't look like cherry-picks because
+  // the committer and author metadata match exactly.  The heuristics below
+  // assume that only a malicious actor could cause these to collide, but we
+  // found an exception.
+  //
+  // FIXME: Consider whether there is a safer solution for this.
+  //
+  // FIXME: Is there a way to add a test for this without having the full
+  // history available?
+  {
+    textual_sha1 text;
+
+    // 8bf1494af87f222db2b637a3be6cee40a9a51a62 is NOT r354826.
+    text.from_input("8bf1494af87f222db2b637a3be6cee40a9a51a62");
+    if (binary_sha1(text) == *commit)
+      return 1;
+  }
+
   if (!metadata)
     if (compute_metadata(commit, metadata))
       return 1;

--- a/src/git_cache.h
+++ b/src/git_cache.h
@@ -454,12 +454,17 @@ int git_cache::compute_rev_with_metadata(sha1_ref commit, int &rev,
     num = parsed_num;
     return 0;
   };
+  auto try_parse_cherry_pick = [&try_parse_string](const char *&current) {
+    // TODO: add tests for the two hits below for this.
+    return try_parse_string(current, "(cherry picked");
+  };
 
   const char *current = parsed.message;
   while (*current) {
     if (!try_parse_string(current, "llvm-rev: ")) {
       int parsed_rev;
-      if (parse_num(current, parsed_rev) || parse_ch(current, '\n'))
+      if (parse_num(current, parsed_rev) || parse_ch(current, '\n') ||
+          !try_parse_cherry_pick(current))
         break;
       rev = parsed_rev;
       note_rev(commit, rev);
@@ -475,7 +480,8 @@ int git_cache::compute_rev_with_metadata(sha1_ref commit, int &rev,
 
     int parsed_rev;
     if (skip_until(current, '@') || parse_ch(current, '@') ||
-        parse_num(current, parsed_rev) || parse_ch(current, ' '))
+        parse_num(current, parsed_rev) || parse_ch(current, ' ') ||
+        !try_parse_cherry_pick(current))
       break;
 
     rev = parsed_rev;


### PR DESCRIPTION
8bf1494af87f is a split commit in github.com/apple/swift-clang that is a
strange style of cherry-pick of r354826.  The strange bit is that the
committer and author metadata match exactly.  This is not supposed to be
possible, since when using `git-cherry-pick` a collision should only
occur when the following all happen in the same second:

- Push to SVN.
- Wait for `git-svn` mirrors to update.
- Fetch.
- Cherry-pick to a branch.

This being vanishingly unlikely, I had assumed only a malicious actor
would add such a commit, and based the heuristics for "is this a
cherry-pick or a real llvm.org commit?" on seeing a mismatch.

Unfortunately there's at least one exception, the above cherry-pick.
Somehow, the committer and author metadata match each other exactly.
The cherry-picker must have done something manual here that accidentally
wiped the author information, since they don't match the upstream
commit.

It's possible there are other cases of this in our histories.  It should
be possible to detect with a scan, looking for `git-svn-id:` where the
metadata matches perfectly but the authorship does not match the
upstream commit.

For now, just blacklist that commit.  We'll need to regenerate the
monorepo to avoid it (we can do that now, or sometime later in a v2).