### PR TITLE
mt-generate: Automatically clean up mt-db worktree if there is no ref

### DIFF
--- a/libexec/apple-llvm/helpers/mt_db.sh
+++ b/libexec/apple-llvm/helpers/mt_db.sh
@@ -50,6 +50,11 @@ mt_db_make_ref() {
 mt_db_make_worktree() {
     local wt="$(mt_db_worktree)"
     local ref="$(mt_db)"
+
+    [ ! -e "$wt" ] ||
+        run --hide-errors git worktree remove "$wt" || run rm -rf "$wt" ||
+        error "could not clean up old worktree: $wt"
+
     # Don't use -q here because some bots have an old git-worktree that doesn't
     # have it.  Instead redirect to /dev/null manually.
     run git worktree add "$wt" "$ref" >/dev/null ||

--- a/test/mt/generate/self-heal-reuse-mtrepo-but-forget-to-remove-mtdb-worktree.test
+++ b/test/mt/generate/self-heal-reuse-mtrepo-but-forget-to-remove-mtdb-worktree.test
@@ -1,0 +1,30 @@
+RUN: mkrepo %t.a
+RUN: mkrepo %t.b
+RUN: env ct=1550000001 mkblob %t.a 1
+RUN: env ct=1550000002 mkblob %t.b 2
+
+RUN: mkrepo --bare %t.out.split
+RUN: mkrepo --bare %t.out.mono
+RUN: rm -rf %t-mt-repo.git 
+RUN: rm -rf %t-mt-configs
+RUN: mkdir -p %t-mt-configs
+RUN: cat         %S/Inputs/generate-branch.mt-config.in | sed -e 's,%%t,%t,' \
+RUN:   | tee %t-mt-configs/generate-branch.mt-config
+
+# Generate, then mostly clean up to try again but leave the worktree behind.
+RUN: %mtgen --git-dir %t-mt-repo.git --config-dir %t-mt-configs generate-branch
+RUN: git -C %t-mt-repo.git show-ref | awk '{print $2}' \
+RUN:   | xargs -L1 git -C %t-mt-repo.git update-ref -d
+RUN: git -C %t-mt-repo.git remote remove out/split
+RUN: git -C %t-mt-repo.git remote remove out/mono
+RUN: mkrepo --bare %t.out.split
+RUN: mkrepo --bare %t.out.mono
+RUN: test -d %t-mt-repo.git/mt-db.checkout
+
+# Generate should still work.
+RUN: %mtgen --git-dir %t-mt-repo.git --config-dir %t-mt-configs generate-branch
+RUN: number-commits -p MONO %t-mt-repo.git master  >%t.map
+RUN: git -C %t-mt-repo.git log master --oneline --no-abbrev-commit \
+RUN:   | apply-commit-numbers %t.map | check-diff %s CHECK %t
+CHECK: MONO-2 mkblob: 2
+CHECK: MONO-1 mkblob: 1


### PR DESCRIPTION
If there's no refs/mt/mt-db and we're creating a new one delete any
existing mt-db worktree.  Having this would have saved me a lot of
annoying delays recently, when I've been reusing an existing
`mt-repo.git` and testing an mt-generate change.