### PR TITLE
mt-generate: Add support for 'upstream' directive

### DIFF
--- a/docs/mt-config.md
+++ b/docs/mt-config.md
@@ -2,12 +2,34 @@
 
 mt-config files consists of declarations of:
 
+- `upstream`, for an upstream mt-config;
 - `repo`, for remote repositories;
 - `destination`, for declaring where to publish the generated refs;
 - `declare-dir`, for declaring the full set of split directories;
 - `repeat`, for repeating commits from another generated branch;
 - `dir`, for declaring which remote branches to use for directory content; and
 - `generate`, for declaring what to generate.
+
+## `upstream`: Declaring an upstream mt-config
+
+```
+upstream <name>
+```
+
+where `<name>` is the name of the mt-config.  The filename is expected to be
+`<name>.mt-config`, adjacent to the config being processed.
+
+`upstream` allows generated monorepos to cascade, ensuring that a downstream
+shares all the refs for an intermediate upstream.  For example, one could
+imagine the following declaration in `internal.mt-config`:
+
+```
+upstream apple
+```
+
+This would cause `internal.mt-config` to be built on top of `apple.mt-config`,
+ensuring that commits mapped by `apple.mt-config` had identical hashes in
+`internal.mt-config`.
 
 ## `repo`: Declaring a repository
 

--- a/libexec/apple-llvm/git-apple-llvm-mt-generate
+++ b/libexec/apple-llvm/git-apple-llvm-mt-generate
@@ -16,14 +16,36 @@ usage() {
         "   --[no-]verbose  Use verbose output (default: \$VERBOSE)"          \
         "   --[no-]setup    Set up and update remotes (default: on)"          \
         "   --[no-]clean    Clean local progress (default: off, for now)"     \
+        "   --[no-]generate Generate branches (default: on)"                  \
         "   --[no-]push     Push to the destination(s) (default: on)"         \
         "   --push-only     Only push previous results"                       \
-        "   --dry-run       Don't actually generate anything"                 \
+        "   --dry-run       Don't actually generate anything, just debug"     \
+        "                   commands that would run"                          \
+        "   --check-for-work"                                                 \
+        "                   Print the first <branch> that needs work, but"    \
+        "                   don't actually do anything"                       \
+        "   --sync-destinations"                                              \
+        "                   Sync destinations repeatedly until there is no"   \
+        "                   work to do, relying on another agent to push it;" \
+        "                   implies --check-for-work"                         \
+        "   --sync-destinations-retries=<count>"                              \
+        "                   Only attempt to sync <count> times"               \
+        "   --sync-destinations-delay=<delay>"                                \
+        "                   Wait <delay> seconds between attempts"            \
+        "   --dump-mt-config"                                                 \
+        "                   Dump the mt-config to stdout"                     \
+        "   --dump-merged-mt-config"                                          \
+        "                   Dump the mt-config merged with its upstream"      \
+        "   --show-upstream Show the upstream, if any"                        \
         "   --show-{monorepo,splitref}-destination"                           \
         "                   Show the monorepo or splitref desitnation repo"   \
         "   --list-actions  List generate actions in order (and exit)"        \
+        "   --list-merged-actions"                                            \
+        "                   List generate actions, including upstream"        \
         "   --list-repos    List repos (and exit)"                            \
         "   --list-branches List branches to generate (and exit)"             \
+        "   --list-merged-branches"                                           \
+        "                   List branches to generate, including upstream"    \
         "   --list-dirs     List declared dirs (and exit)"                    \
         "   --list-(active|inactive|repeat)-dirs=<branch>"                    \
         "                   List active, inactive, or repeated dirs for"      \
@@ -42,6 +64,7 @@ print_list() {
     shift
     local which="$list"
     case "$list" in
+        --show-upstream) show_upstream; return $? ;;
         --show-monorepo-destination) show_monorepo_destination; return $? ;;
         --show-splitref-destination) show_splitref_destination; return $? ;;
         *) true ;;
@@ -54,24 +77,28 @@ print_list() {
     is_function print_"$which" || usage_error "unknown option '$list'"
     print_"$which" "$@"
 }
-print_actions() {
-    cat "$MT_CONFIG" | awk '$1 == "generate" {print $2, $3}'
+print_actions_impl()   { cat "$1" | awk '$1 == "generate" {print $2, $3}'; }
+print_actions()        { print_actions_impl "$MT_CONFIG"; }
+print_merged_actions() { print_actions_impl "$MERGED_MT_CONFIG"; }
+print_repos() { cat "$MERGED_MT_CONFIG" | awk '$1 == "repo" {print $2, $3}'; }
+print_branches_impl() {
+    print_actions_impl "$1" | awk '$1 == "branch" {print $2}' | sort
 }
-print_repos() { cat "$MT_CONFIG" | awk '$1 == "repo" {print $2, $3}'; }
-print_branches() { print_actions | awk '$1 == "branch" {print $2}' | sort; }
+print_branches()        { print_branches_impl "$MT_CONFIG"; }
+print_merged_branches() { print_branches_impl "$MERGED_MT_CONFIG"; }
 print_dirs() {
-    cat "$MT_CONFIG" | awk '$1 == "declare-dir" {print $2}' | sort
+    cat "$MERGED_MT_CONFIG" | awk '$1 == "declare-dir" {print $2}' | sort
 }
 print_repeat() {
     awk -v branch="$1" '
     $1 == "repeat" && $2 == branch {
         if (any) {
-            printf "error: %s:%s: second repeat for branch %s\n" >"/dev/stderr"
+            printf "error: second repeat for branch %s\n", branch >"/dev/stderr"
             exit 1
         }
         print $3
         any = 1
-    }' "$MT_CONFIG"
+    }' "$MERGED_MT_CONFIG"
 }
 print_active_dirs()      { print_dirs_impl "$1" 1 0 0 0 0; }
 print_inactive_dirs()    { print_dirs_impl "$1" 0 1 0 0 0; }
@@ -85,7 +112,22 @@ print_dirs_impl() {
     local branch="$1" undecl=$6
     awk_helper mt-config-dirs -v branch="$branch" -v active=$2              \
         -v inactive=$3 -v repeat=$4 -v refs=$5 -v undecl=$undecl            \
-        "$MT_CONFIG" "$MT_CONFIG"
+        "$MERGED_MT_CONFIG" "$MERGED_MT_CONFIG"
+}
+
+show_upstream() {
+    run cat "$MT_CONFIG" |
+    awk '
+    $1 == "upstream" {
+        if (upstream) {
+            printf "error: second upstream declaration not supported\n" >"/dev/stderr"
+            printf "note: 1st upstream: %s\n", upstream >"/dev/stderr"
+            printf "note: 2nd upstream: %s\n", $2 >"/dev/stderr"
+            exit 1
+        }
+        upstream = $2
+    }
+    END { if (upstream) print upstream }'
 }
 
 show_monorepo_destination() { show_destination monorepo; }
@@ -116,11 +158,63 @@ show_destination() {
     }'
 }
 
+validate_mt_config() {
+    # Check repos aren't duplicated.
+    print_repos | awk '
+    names[$1] {
+        printf "error: duplicate repo name '\''%s'\''\n", $1 >"/dev/stderr"
+        exit 1
+    }
+    urls[$2] {
+        printf "error: duplicate repo url '\''%s'\''\n", $2 >"/dev/stderr"
+        exit 1
+    }
+    { names[$1]=1; urls[$2]=1 }
+    ' || return 1
+
+    # Check branches aren't duplicated.
+    print_merged_branches | awk '
+    branches[$1] {
+        printf "error: duplicate branch '\''%s'\''\n", $1 >"/dev/stderr"
+        exit 1
+    }
+    { branches[$1]=1 }
+    ' || return 1
+
+    # Check directories aren't duplicated.
+    print_dirs | awk '
+    dirs[$1] {
+        printf "error: re-declared directory '\''%s'\''\n", $1 >"/dev/stderr"
+        exit 1
+    }
+    { dirs[$1]=1 }
+    ' || return 1
+
+    # Check that there is at most one mapping and that we don't have an
+    # upstream if we have a mapping.
+    print_actions | awk -v upstream="$(show_upstream)" '
+    $1 != "mapping" { next }
+    upstream {
+        printf                                                                \
+            "error: cannot have upstream '\''%s'\'' and mapping '\''%s'\''\n",\
+            upstream, $2 >"/dev/stderr"
+        exit 1
+    }
+    mapping {
+        printf "error: too many mappings: '\''%s'\'' and '\''%s'\''\n",       \
+            mapping, $2 >"/dev/stderr"
+        exit 1
+    }
+    { mapping=$2 }
+    ' || return 1
+}
 MTDB_REF=refs/mt/mt-db
 MTDB_SHA1= MTDB_LOCAL_REF=
+mtdb_local_ref() { printf "%s.%s\n" "$MTDB_REF" "$1"; }
 mt_setup() {
     GIT_DIR="$(canonicalize_path "$GIT_DIR")"
     MT_CONFIG="$(canonicalize_path "$MT_CONFIG")"
+    CONFIG_DIR="$(canonicalize_path "$CONFIG_DIR")"
 
     # Always change directory.
     if ! should_setup; then
@@ -129,50 +223,30 @@ mt_setup() {
     fi
 
     # Verbose output.
-    local gitout=/dev/null
-    local hide=--hide-errors
-    if [ ! "${VERBOSE:-0}" = 0 ]; then
-        gitout=/dev/stdout
-        hide=
-    fi
+    local gitout hide
+    setup_gitout_and_hide
 
     # Clean up any local progress.
-    if should_clean; then
-        local existing
-        existing="$(git show-ref | grep -e ^refs/mt -e ^refs/heads |
-            awk '{print $2}')" ||
-            error "failed to look up refs to clean"
-        [ -z "$existing" ] || run git update-ref -d $existing ||
-            error "failed to clean local refs: $existing"
-        local prev_existing=
-        while existing="$(git worktree list --porcelain |
-            awk '$1=="worktree"{print substr($0,10); exit 0} END{exit 1}')"; do
-            # Prevent an infinite loop, if somehow we stop making progress.
-            # Probably not actaully reachable, but better to be paranoid.
-            [ ! "$prev_existing" = "$existing" ] ||
-                error "failed to clean worktrees"
-            prev_existing="$existing"
-
-            run git worktree remove --force "$existing" ||
-                error "failed to clean worktree: $existing"
-        done
-    fi
+    ! should_clean || clean || exit 1
 
     log "Setting up and syncing $GIT_DIR"
     log "  (based on $MT_CONFIG)"
     [ -d "$GIT_DIR" ] ||
-        run --hide-errors git init --bare "$GIT_DIR" >$gitout ||
+        run --hide-errors git init -q --bare "$GIT_DIR" >$gitout ||
         error "failed to initialize '$GIT_DIR'"
     run cd "$GIT_DIR" || error "failed to cd to $GIT_DIR"
     log "Updating remotes in parallel"
 
-    print_repos | {
-        local forks= name= url= clone=
+    # Set up repos in reverse so that upstream repos are fetched last and are
+    # more likely to be up-to-date.
+    reverse_lines() {
+        awk '{row[NR] = $0} END{for(r=NR; r; r = r-1){print row[r]}}'
+    }
+    print_repos | reverse_lines | {
+        local name= url=
         while read name url; do
-            mt_setup_repo &
-            forks="$forks $!"
+            mt_setup_repo || return 1
         done
-        run wait $forks
     } || return 1
 
     log "Combining object databases"
@@ -181,7 +255,7 @@ mt_setup() {
         log "  - $name"
         # Ignore errors here, since often the remote will already exist.
         run --hide-errors git remote add $name $PWD/clones/$name.git >$gitout
-        run $hide git fetch --no-tags $name >$gitout ||
+        run $hide git fetch -q --no-tags $name >$gitout ||
         error "failed to sync '$GIT_DIR'"
     done || return 1
 
@@ -196,11 +270,127 @@ mt_setup() {
         error "monorepo destination '$monodest' is not a repo"
 
     # Fetch the mt-db ref.
+    fetch_destination_mtdb "$monodest" || exit 1
+}
+fetch_destination_mtdb() {
+    local monodest="$1"
     log "Syncing mt-db from $monodest"
     MTDB_SHA1=$(run git ls-remote $monodest $MTDB_REF | awk '{print $1}')
     [ -n "$MTDB_SHA1" ] || return 0
-    run git fetch --force $monodest $MTDB_REF:$MTDB_LOCAL_REF ||
+    run git fetch -q --force $monodest $MTDB_REF:$MTDB_LOCAL_REF ||
         error "failed to fetch $MTDB_REF from $monodest"
+}
+
+setup_gitout_and_hide() {
+    gitout=/dev/null
+    hide=--hide-errors
+    if [ ! "${VERBOSE:-0}" = 0 ]; then
+        gitout=/dev/stderr
+        hide=
+    fi
+}
+
+clean() {
+    local existing
+    existing="$(git show-ref | grep -e ^refs/mt -e ^refs/heads |
+        awk '{print $2}')" ||
+        error "failed to look up refs to clean"
+    [ -z "$existing" ] || run git update-ref -d $existing ||
+        error "failed to clean local refs: $existing"
+    local prev_existing=
+    while existing="$(git worktree list --porcelain |
+        awk '$1=="worktree"{print substr($0,10); exit 0} END{exit 1}')"; do
+        # Prevent an infinite loop, if somehow we stop making progress.
+        # Probably not actaully reachable, but better to be paranoid.
+        [ ! "$prev_existing" = "$existing" ] ||
+            error "failed to clean worktrees"
+        prev_existing="$existing"
+
+        run git worktree remove --force "$existing" ||
+            error "failed to clean worktree: $existing"
+    done
+}
+
+MERGED_MT_CONFIG=
+initialize_merged_mt_config() {
+    local upstream
+    upstream="$(show_upstream)" || exit 1
+    if [ -z "$upstream" ]; then
+        MERGED_MT_CONFIG="$MT_CONFIG"
+        return 0
+    fi
+
+    MERGED_MT_CONFIG="$(mktemp -q)" ||
+        error "failed to generate temp file for merged mt-config"
+    mt_register_paths_to_clean_up "$MERGED_MT_CONFIG"
+
+    local grepexpr="^upstream "
+    run git apple-llvm mt generate --config-dir "$CONFIG_DIR" \
+        --dump-merged-mt-config "$upstream" |
+    grep -v "$grepexpr" >"$MERGED_MT_CONFIG" ||
+        error "could not create merged mt-config from upstream '$upstream'"
+    run cat "$MT_CONFIG" | run grep -v "$grepexpr" >>"$MERGED_MT_CONFIG" ||
+        error "could not patch merged mt-config for '$NAME'"
+}
+
+sync_upstream_destinations() {
+    [ -n "$upstream" ] ||
+        error "internal: sync_upstream_destinations called without upstream?"
+
+    log "Syncing destination repos for upstream '$upstream'"
+    run git apple-llvm mt generate --sync-destinations \
+        --sync-destinations-delay=$SYNC_DELAY \
+        --sync-destinations-retries=$SYNC_RETRIES \
+        --config-dir="$CONFIG_DIR" --git-dir="$GIT_DIR" \
+        "$upstream"
+    local status=$?
+    log "Finished syncing destination repos for upstream '$upstream'"
+    [ $status = 0 ] || error "upstream '$upstream' out-of-date"
+}
+fetch_destinations() {
+    print_repos | run awk -v m="$monorepo" -v s="$splitref" \
+        '$1 == m || $1 == s { print $0 }' |
+    while read name url; do
+        mt_setup_repo || exit 1
+        run $hide git fetch -q --no-tags $name >$gitout ||
+            error "failed to sync '$GIT_DIR'"
+    done || exit 1
+
+    fetch_destination_mtdb "$monorepo" || exit 1
+}
+sync_destinations() {
+    # Look up destinations.
+    local monorepo splitref
+    monorepo="$(show_monorepo_destination)" ||
+        error "could not extract monorepo destination"
+    splitref="$(show_splitref_destination)" ||
+        error "could not extract splitref destination"
+
+    # Configure verbose output for mt_setup_repo.
+    local gitout hide
+    setup_gitout_and_hide
+
+    # Fetch destinations.
+    log "Fetching destinations..."
+    fetch_destinations
+
+    # Double-check check-for-work is enabled...
+    check_for_work || error "--sync-destinations implies --check-for-work?"
+
+    # Check for work, and then repeat as long as there's work to do.
+    local actions
+    while true; do
+        actions="$(generate_actions)" || exit 1
+        [ -n "$actions" ] || return 0
+        [ $SYNC_RETRIES -gt 0 ] ||
+            error "too many retries for --sync-destinations, giving up"
+        SYNC_RETRIES=$(( $SYNC_RETRIES - 1 ))
+        sleep $SYNC_DELAY
+
+        # Fetch the destinations again.
+        log "Fetching destinations again..."
+        fetch_destinations || exit 1
+    done
 }
 
 mt_check_clone() {
@@ -253,7 +443,7 @@ mt_make_clone() {
     [ -e "$clone" ] && return 1
 
     run $hide mkdir -p $(dirname $clone) &&
-        run $hide git init --bare $clone  &&
+        run $hide git init -q --bare $clone  &&
         run $hide git -C $clone remote add --mirror=fetch origin $url &&
         return 0
 
@@ -271,7 +461,36 @@ mt_setup_repo() {
         error "failed to update remote '$name'"
 }
 
+report_work() {
+    printf "work: generate %s %s\n" "$1" "$2"
+    exit 0
+}
+
+generate_actions() {
+    # Handle implicit action for syncing upstream.
+    local upstream
+    upstream="$(show_upstream)" || exit 1
+    if [ -n "$upstream" ]; then
+        log "Syncing mt-db with $upstream"
+        sync_upstream_before_generate "$upstream" ||
+            error "failed to sync upstream '$upstream'"
+    fi
+
+    # Handle explicit actions.
+    print_actions |
+    while read action object; do
+        mt_generate "$action" "$object" ||
+            error "failed to generate '$action' using '$object'"
+    done
+}
+
 has_no_spaces() { [ "${1/ /}" = "$1" ]; }
+set_mtdb_symbolic_ref() {
+    [ "$(git symbolic-ref "$MTDB_REF" 2>/dev/null)" = "$MTDB_LOCAL_REF" ] ||
+        run git symbolic-ref -m "mt generate" "$MTDB_REF" "$MTDB_LOCAL_REF" ||
+        error "failed to set up $MTDB_REF"
+
+}
 mt_generate() {
     local action="$1"
     local object="$2"
@@ -279,12 +498,8 @@ mt_generate() {
     local fetcher="mt_fetch_$action"
     local pusher="mt_push_$action"
 
-    [ "$(git symbolic-ref "$MTDB_REF" 2>/dev/null)" = "$MTDB_LOCAL_REF" ] ||
-        run git symbolic-ref -m "mt generate" "$MTDB_REF" "$MTDB_LOCAL_REF" ||
-        error "failed to set up $MTDB_REF"
-
-    mt_llvm_svn2git_init ||
-        error "generate: could not initialize svn2git"
+    set_mtdb_symbolic_ref || exit 1
+    mt_db_init || error "generate: could not initialize mt-db"
 
     # Check that we have a generator for this.
     is_function "$generator" ||
@@ -296,11 +511,23 @@ mt_generate() {
     has_no_spaces "$object" ||
         error "generate: invalid object '$object'"
 
-    log "Generating $action for $object"
-    push_only || $fetcher "$object" || exit 1
-    push_only || $generator "$object" || exit 1
+    if check_for_work; then
+        log "Checking for work to generate $action for $object"
+    else
+        log "Generating $action for $object"
+    fi
+
+    # Invoke through wrappers whose logic can be reused.
+    mt_fetcher   "$fetcher"   "$object" || exit 1
+    mt_generator "$generator" "$object" || exit 1
+    mt_pusher    "$pusher"    "$object" || exit 1
+}
+mt_fetcher()   { should_fetch    || return 0; "$@"; }
+mt_generator() { should_generate || return 0; "$@"; }
+mt_pusher() {
+    ! check_for_work || return 0
     should_push || return 0
-    $pusher "$object" || exit 1
+    "$@"
 }
 
 mt_generate_mapping() {
@@ -317,6 +544,7 @@ mt_generate_mapping() {
             log "Mapping for '$branch' up-to-date"
             continue
         fi
+        ! check_for_work || report_work mapping "$remote"
         log "Generating mapping for '$branch'"
         run --dry git apple-llvm mt llvm-svn2git-map $branch ||
             error "failed to generate mapping for '$branch'"
@@ -328,7 +556,9 @@ mt_fetch_mapping() {
     true
 }
 
-mt_push_mapping() {
+mt_push_mapping() { push_mtdb; }
+
+push_mtdb() {
     local old_mtdb_sha1=$MTDB_SHA1
     MTDB_SHA1=$(run git show-ref $MTDB_REF | awk '{print $1}')
     [ ! "$old_mtdb_sha1" = "$MTDB_SHA1" ] || return 0
@@ -344,6 +574,45 @@ mt_push_mapping() {
         run --dry git -C clones/$monodest.git push origin $MTDB_REF:$MTDB_REF \
             --force-with-lease=$MTDB_REF:$old_mtdb_sha1
     } || error "failed to push $MTDB_REF to $monodest"
+}
+
+sync_upstream_before_generate() {
+    [ -n "$upstream" ] ||
+        error "internal: sync_upstream_before_generate called without upstream?"
+
+    # Do some things with upstream.  This can set MTDB_REF to upstream.
+    mt_fetcher fetch_upstream || exit 1
+    local upstream_monorepo
+    upstream_monorepo="$(run git apple-llvm mt generate \
+        --show-monorepo-destination \
+        --config-dir="$CONFIG_DIR" --git-dir="$GIT_DIR" \
+        "$upstream")" ||
+        error "failed to lookup monorepo destination for '$upstream'"
+
+    # Reset MTDB_REF to downstream and get ready to work.
+    set_mtdb_symbolic_ref || exit 1
+    mt_db_init || error "generate: could not initialize svn2git"
+
+    # Find the upstream ref.
+    local mtdb_upstream_ref="$(mtdb_local_ref "$upstream")"
+    run git fetch -q -f "$upstream_monorepo" $MTDB_REF:$mtdb_upstream_ref ||
+        error "failed to fetch $mtdb_upstream_ref"
+
+    if check_for_work; then
+        mt_db_check_upstream "$upstream" || report_work upstream "$upstream"
+    else
+        mt_db_merge_upstream "$upstream" ||
+            error "failed to merge upstream '$upstream'"
+        mt_db_save || exit 1
+        mt_pusher push_mtdb || exit 1
+    fi
+}
+
+fetch_upstream() {
+    # Sync upstream destinations.
+    [ -n "$upstream" ] ||
+        error "internal: fetch_upstream called without upstream?"
+    sync_upstream_destinations || exit 1
 }
 
 mt_generate_branch() {
@@ -383,6 +652,15 @@ mt_generate_branch() {
 
     refdirs="$(print_all_refdirs "$rawbranch")" ||
         error "failed to extract complete refdirs for $rawbranch"
+
+    if check_for_work; then
+        local work
+        work="$(run git apple-llvm mt translate-branch $branch $refdirs \
+            --check-for-work)" ||
+            error "failed to check for work on branch '$branch'"
+        [ -n "$work" ] && report_work branch "$branch"
+        return 0
+    fi
 
     run --dry git apple-llvm mt translate-branch $branch $refdirs ||
         error "failed to generate branch '$branch'"
@@ -516,6 +794,15 @@ mt_generate_splitrefs() {
             error "generate $branch: invalid dir '$dir' for ref '$ref'"
     done
 
+    if check_for_work; then
+        local work
+        work="$(run git apple-llvm mt update-splitrefs --check-for-work \
+            $branch $refdirs)" ||
+            error "failed to check for work on branch '$branch'"
+        [ -n "$work" ] && report_work splitrefs "$branch"
+        return 0
+    fi
+
     run --dry git apple-llvm mt update-splitrefs $branch $refdirs ||
         error "failed to update splitrefs for '$branch'"
 }
@@ -524,11 +811,17 @@ CONFIG_DIR="$DEFAULT_CONFIG_DIR"
 GIT_DIR=$DEFAULT_GIT_DIR
 
 # FIXME: consider setting CLEAN=1 by default.
-SETUP=1 CLEAN=0 PUSH=1 PUSH_ONLY=0
+SETUP=1 CLEAN=0 FETCH=1 GENERATE=1 PUSH=1 PUSH_ONLY=0 CHECK_FOR_WORK=0
+DUMP= SYNC=0 SYNC_RETRIES=30 SYNC_DELAY=60 ONLY_VALIDATE=0
 should_setup() { [ ! "${SETUP:-0}" = 0 ]; }
 should_clean() { [ ! "${CLEAN:-0}" = 0 ]; }
+should_fetch() { [ ! "${FETCH:-0}" = 0 ]; }
+should_generate() { [ ! "${GENERATE:-0}" = 0 ]; }
 should_push() { [ ! "${PUSH:-0}" = 0 ]; }
 push_only() { [ ! "${PUSH_ONLY:-0}" = 0 ]; }
+only_validate() { [ ! "${ONLY_VALIDATE:-0}" = 0 ]; }
+check_for_work() { [ ! "${CHECK_FOR_WORK:-0}" = 0 ]; }
+should_sync_destinations() { [ ! "${SYNC:-0}" = 0 ]; }
 NAME=
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -549,11 +842,30 @@ while [ $# -gt 0 ]; do
         --dry-run)  DRY_RUN=1; shift ;;
         --setup)    SETUP=1; shift ;;
         --no-setup) SETUP=0; shift ;;
+        --validate-mt-config) ONLY_VALIDATE=1; shift ;;
         --push)     PUSH=1; shift ;;
         --no-push)  PUSH=0; shift ;;
         --clean)    CLEAN=1; shift ;;
         --no-clean) CLEAN=0; shift ;;
-        --push-only)PUSH_ONLY=1; shift ;;
+        --push-only)PUSH_ONLY=1 GENERATE=0 FETCH=0; shift ;;
+        --generate)     GENERATE=1; shift ;;
+        --no-generate)  GENERATE=0; shift ;;
+        --check-for-work) CHECK_FOR_WORK=1; shift ;;
+        --dump-merged-mt-config) DUMP=merged; shift ;;
+        --dump-mt-config)        DUMP=raw;    shift ;;
+        --sync-destinations) SYNC=1; CHECK_FOR_WORK=1; shift ;;
+        --sync-destinations-retries|--sync-destinations-retries=*)
+            parse_cmdline_option --sync-destinations-retries SYNC_RETRIES "$@"
+            shift $?
+            [ "$SYNC_RETRIES" -ge 0 ] 2>/dev/null ||
+                usage_error "invalid argument for --sync-destinations-retries"
+            ;;
+        --sync-destinations-delay|--sync-destinations-delay=*)
+            parse_cmdline_option --sync-destinations-delay SYNC_DELAY "$@"
+            shift $?
+            [ "$SYNC_DELAY" -ge 0 ] 2>/dev/null ||
+                usage_error "invalid argument for --sync-destinations-delay"
+            ;;
         --list-*-*dirs|--list-*-*dirs=*)
             LIST="$1"
             parse_cmdline_option "--list-*-*dirs" LIST_BRANCH "$@"
@@ -580,7 +892,7 @@ while [ $# -gt 0 ]; do
             MT_CONFIG="$CONFIG_DIR/$NAME.mt-config"
             [ -r "$MT_CONFIG" ] ||
                 usage_error "cannot read '$MT_CONFIG'"
-            MTDB_LOCAL_REF="$MTDB_REF.$NAME"
+            MTDB_LOCAL_REF="$(mtdb_local_ref $NAME)"
             shift
             ;;
     esac
@@ -590,16 +902,41 @@ if push_only && should_clean; then
     usage_error "refusing to --clean when invoked with --push-only"
 fi
 
+if push_only && check_for_work; then
+    usage_error "--push-only doesn't make sense with --check-for-work"
+fi
+
+# Nothing to push if we're just checking for work.
+check_for_work && PUSH=0
+
 [ -n "$MT_CONFIG" ] || usage_error "missing name of mt-config"
+
+if [ "$DUMP" = raw ]; then
+    cat "$MT_CONFIG" || error "could not read $MT_CONFIG"
+    exit 0
+fi
+initialize_merged_mt_config || exit 1
+
+validate_mt_config || exit 1
+! only_validate || exit 0
+
+if [ "$DUMP" = merged ]; then
+    cat "$MERGED_MT_CONFIG"
+    exit 0
+elif [ -n "$DUMP" ]; then
+    error "internal: invalid '\$DUMP' value '$DUMP'"
+fi
+
 if [ -n "$LIST" ]; then
     print_list "$LIST" "$LIST_BRANCH"
     exit $?
 fi
 
+if should_sync_destinations; then
+    sync_destinations
+    exit $?
+fi
+
 mt_setup || exit 1
-print_actions |
-while read action object; do
-    mt_generate "$action" "$object" ||
-        error "failed to generate '$action' using '$object'"
-done
+generate_actions || exit 1
 exit $?

--- a/libexec/apple-llvm/git-apple-llvm-mt-translate-branch
+++ b/libexec/apple-llvm/git-apple-llvm-mt-translate-branch
@@ -7,7 +7,7 @@ helper mt_list_commits
 
 usage() {
     printf "%s\n" \
-        "usage: $(print_cmdname) <branch> <ref>:<dir>..."                   \
+        "usage: $(print_cmdname) [options] <branch> <ref>:<dir>..."         \
         ""                                                                  \
         "   <branch>      the branch to interleave"                         \
         "   <ref>         a ref to interleave commits from"                 \
@@ -16,17 +16,25 @@ usage() {
         "                     other refs)"                                  \
         "                   '-' if there is no relevant split repo"         \
         "   <dir>         the name of the top-level tree to put <ref> into" \
-        "                   '-' for root (splat contents)"
+        "                   '-' for root (splat contents)"                  \
+        ""                                                                  \
+        "  --check-for-work"                                                \
+        "                 print <branch> if there's work (but don't do it)"
 }
 
 main() {
     [ $# -ge 1 ] || usage_error "missing <branch>"
     [ $# -ge 2 ] || usage_error "missing <ref>:<dir>..."
 
-    mt_split2mono_init &&
-    translate_branch "$@" &&
+    mt_split2mono_init || return 1
+    translate_branch "$@" || return 1
+
+    ! check_for_work || return 0
     mt_split2mono_save
 }
+
+CHECK_FOR_WORK=0
+check_for_work() { [ ! "${CHECK_FOR_WORK:-0}" = 0 ]; }
 
 translate_branch() {
     local branch
@@ -39,6 +47,7 @@ translate_branch() {
                 usage
                 exit 0
                 ;;
+            --check-for-work) CHECK_FOR_WORK=1; shift ;;
             *:*)
                 [ $pos -ne 0 ] || usage_error "invalid branch name '$1'"
                 refdirs=( "${refdirs[@]}" "$1" )
@@ -125,12 +134,46 @@ translate_branch() {
     fi
 
     list_new_commits "$branch" "${listdirs[*]}" "${repeated[*]}" $until |
+    process_new_commits
+    local status=$?
+    [ $status -ne $REPORT_WORK ] || exit 0
+    [ $status -eq 0 ] || exit $status
+}
+
+REPORT_WORK=27
+process_new_commits() {
+    if check_for_work; then
+        local num_commits
+        while read num_commits; do
+            # If there are no commits, continue.  Ignore errors from
+            # non-integer input for now.
+            [ "$num_commits" -eq 0 ] 2>/dev/null && continue
+
+            # Validate commit count.
+            [ "$num_commits" -ne 0 ] 2>/dev/null ||
+                error "--check-for-work: invalid number of commits"
+
+            # Report that there's work to do.
+            printf "%s\n" "$branch"
+
+            # Eat up the rest of the counts to avoid SIGPIPE.
+            cat >/dev/null
+            return $REPORT_WORK
+        done
+
+        # There's nothing to do.
+        return 0
+    fi
+
     interleave_commits "$branch" "${sha1dirs[*]}" |
     update_refs "$branch" "$current" "${sha1dirs[*]}" ||
         error "failure interleaving commits"
 }
 
 list_new_commits() {
+    local commit_lister=mt_list_commits
+    ! check_for_work || commit_lister=mt_count_commits
+
     local branch="$1"
     local refdirs="$2"
     local repeated="$3"
@@ -181,7 +224,7 @@ list_new_commits() {
             extra="$extra${extra_repeated:+ }$extra_repeated"
         fi
 
-        mt_list_commits "$d" $headref --not $nots $extra ||
+        $commit_lister "$d" $headref --not $nots $extra ||
             error "failed to list new commits for $rd"
     done
 }

--- a/libexec/apple-llvm/git-apple-llvm-mt-translate-branch
+++ b/libexec/apple-llvm/git-apple-llvm-mt-translate-branch
@@ -134,13 +134,10 @@ translate_branch() {
     fi
 
     list_new_commits "$branch" "${listdirs[*]}" "${repeated[*]}" $until |
-    process_new_commits
-    local status=$?
-    [ $status -ne $REPORT_WORK ] || exit 0
-    [ $status -eq 0 ] || exit $status
+    process_new_commits ||
+        exit 1
 }
 
-REPORT_WORK=27
 process_new_commits() {
     if check_for_work; then
         local num_commits
@@ -153,12 +150,11 @@ process_new_commits() {
             [ "$num_commits" -ne 0 ] 2>/dev/null ||
                 error "--check-for-work: invalid number of commits"
 
-            # Report that there's work to do.
+            # Report that there's work to do and then exit, after eating up
+            # remaining input to prevent a broken pipe.
             printf "%s\n" "$branch"
-
-            # Eat up the rest of the counts to avoid SIGPIPE.
             cat >/dev/null
-            return $REPORT_WORK
+            exit 0
         done
 
         # There's nothing to do.

--- a/libexec/apple-llvm/git-apple-llvm-mt-update-splitrefs
+++ b/libexec/apple-llvm/git-apple-llvm-mt-update-splitrefs
@@ -6,16 +6,27 @@ helper mt_split2mono
 
 usage() {
     printf "%s\n" \
-        "usage: $(print_cmdname) [options] <branch> <ref>:<dir>..."         \
+        "usage: $(print_cmdname) [--check-for-work] <branch> <ref>:<dir>..."\
         ""                                                                  \
-        "  update <branch> refs ending in /mt-split based on the given"     \
-        "  <ref>:<dir> info"
+        "  Update <branch> refs ending in /mt-split based on the given"     \
+        "  <ref>:<dir> info"                                                \
+        ""                                                                  \
+        "  --check-for-work     Print the refs that need to be updated,"    \
+        "                       but don't update them"
 }
 
-[ "$#" -ge 1 ] || usage_error "missing <branch>"
-[ "$#" -ge 2 ] || usage_error "missing <ref>:<dir> (minimum 1)"
+CHECK_FOR_WORK=0
+check_for_work() { [ ! "${CHECK_FOR_WORK:-0}" = 0 ]; }
 
 main() {
+    if [ "$1" = --check-for-work ]; then
+        CHECK_FOR_WORK=1
+        shift
+    fi
+
+    [ "$#" -ge 1 ] || usage_error "missing <branch>"
+    [ "$#" -ge 2 ] || usage_error "missing <ref>:<dir> (minimum 1)"
+
     local branch="${1#refs/heads/}"
     shift
     mt_split2mono_init || exit 1
@@ -47,6 +58,12 @@ update_splitref() {
     local last_mapped="$(run git rev-list -1 $mapped)"
     [ -n "$last_mapped" ] || return 0
     [ "$already_mapped" = "$last_mapped" ] && return 0
+
+    if check_for_work; then
+        printf "%s\n" "$mtref"
+        return 0
+    fi
+
     log " - ${mtref#refs/heads/} => $last_mapped"
     run git update-ref $mtref $last_mapped ||
         error "failed to update $mtref"

--- a/libexec/apple-llvm/helpers/mt_db.sh
+++ b/libexec/apple-llvm/helpers/mt_db.sh
@@ -1,14 +1,16 @@
 # vim: ft=sh
 
-mt_db() { printf "%s\n" refs/mt/mt-db; }
-mt_db_worktree() { printf "%s\n" "$GIT_DIR"/mt-db.checkout; }
+mt_db()          { printf "%s\n" refs/mt/mt-db; }
+mt_db_upstream() { printf "%s.%s\n" "$(mt_db)" "$1"; }
+mt_db_worktree()          { printf "%s\n"    "$GIT_DIR"/mt-db.checkout; }
+mt_db_worktree_upstream() { printf "%s/%s\n" "$GIT_DIR"/mt-db-$1.checkout; }
 
 mt_db_init() {
     [ -z "$MT_DB_INIT_ONCE" ] || return 0
     MT_DB_INIT_ONCE=1
 
     local ref=$(mt_db)
-    run --hide-errors git symbolic-ref "$ref" ||
+    run --hide-errors git symbolic-ref "$ref" >/dev/null ||
         error "expected symbolic ref: $ref"
 
     local wt="$(mt_db_worktree)"
@@ -29,7 +31,7 @@ mt_db_init() {
     esac
     if [ -d "$wt" ]; then
         # Reset to match the ref.
-        run --hide-errors git -C "$wt" reset --hard "$ref" >/dev/null ||
+        run --hide-errors git -C "$wt" reset --hard -q "$ref" ||
             error "internal: failed to reset $wt"
     else
         # Handle a pre-existing ref with no worktree.
@@ -117,4 +119,43 @@ mt_db_save() {
         error "failed to commit mt-db to $ref"
     run git -C "$wt" update-ref $ref HEAD ||
         error "failed to update $ref to HEAD"
+}
+
+mt_db_merge_upstream() { mt_db_upstream_impl "$1" 0; }
+mt_db_check_upstream() { mt_db_upstream_impl "$1" 1; }
+
+mt_db_upstream_impl() {
+    local upstream="$1" dryrun="$2"
+    local uref="$(mt_db_upstream "$1")" uwt="$(mt_db_worktree_upstream "$1")"
+    if [ -d "$uwt" ]; then
+        run --hide-errors git -C "$uwt" reset --hard -q "$uref" ||
+            error "failed to reset worktree to $uref at '$uwt'"
+    else
+        run git worktree add "$uwt" "$uref" >/dev/null ||
+            error "failed to create worktree for $uref at '$uwt'"
+    fi
+
+    local usvn2gitdb="$uwt"/svn2git.db
+    local usplit2monodb="$uwt/"split2mono.db
+    [ -r "$usvn2gitdb" ] || error "could not read '$usvn2gitdb'"
+    [ -r "$usplit2monodb" ] || error "could not read '$usplit2monodb'"
+
+    local svn2git split2mono
+    svn2git="$(build_executable svn2git)" ||
+        error "could not build svn2git"
+    split2mono="$(build_executable split2mono)" ||
+        error "could not build split2mono"
+
+    if [ "${dryrun:-0}" = 0 ]; then
+        # Do the merge.
+        run "$split2mono" upstream "$MT_DB_SPLIT2MONO_DB" "$usplit2monodb" ||
+            error "could not update split2mono from '$upstream'"
+        run cp "$usvn2gitdb" "$MT_DB_SVN2GIT_DB" ||
+            error "could not update svn2git from '$upstream'"
+    else
+        # Check for things to do in the merge.
+        run --hide-errors "$split2mono" check-upstream \
+            "$MT_DB_SPLIT2MONO_DB" "$usplit2monodb" || return 1
+        diff -q "$usvn2gitdb" "$MT_DB_SVN2GIT_DB" || return 1
+    fi
 }

--- a/libexec/apple-llvm/helpers/mt_list_commits.sh
+++ b/libexec/apple-llvm/helpers/mt_list_commits.sh
@@ -11,3 +11,9 @@ mt_list_commits() {
         --boundary "$@" &&
     run printf "done\n"
 }
+
+mt_count_commits() {
+    local d="$1"
+    shift
+    run git rev-list --count "$@"
+}

--- a/src/split2mono.cpp
+++ b/src/split2mono.cpp
@@ -73,6 +73,7 @@ static int usage(const std::string &msg, const char *cmd) {
           "       %s lookup             <dbdir> <split>\n"
           "       %s lookup-svnbase     <dbdir> <sha1>\n"
           "       %s upstream           <dbdir> <upstream-dbdir>\n"
+          "       %s check-upstream     <dbdir> <upstream-dbdir>\n"
           "       %s insert             <dbdir> [<split> <mono>]\n"
           "       %s insert-svnbase     <dbdir> <sha1> <rev>\n"
           "       %s interleave-commits <dbdir> <svn2git-db>\n"
@@ -83,7 +84,7 @@ static int usage(const std::string &msg, const char *cmd) {
           "       <dir>     '-'         root\n"
           "                 000...0     not yet started\n"
           "       <sha1>    '-'         untracked\n",
-          cmd, cmd, cmd, cmd, cmd, cmd, cmd, cmd);
+          cmd, cmd, cmd, cmd, cmd, cmd, cmd, cmd, cmd);
   return 1;
 }
 
@@ -353,6 +354,37 @@ static int main_upstream(const char *cmd, int argc, const char *argv[]) {
   return 0;
 }
 
+static int main_check_upstream(const char *cmd, int argc, const char *argv[]) {
+  if (argc != 2)
+    return usage("upstream: wrong number of positional arguments", cmd);
+  split2monodb main, upstream;
+  upstream.is_read_only = main.is_read_only = true;
+  if (main.opendb(argv[0]) || main.parse_upstreams())
+    return usage("could not open <dbdir>", cmd);
+  if (upstream.opendb(argv[1]) || upstream.parse_upstreams())
+    return usage("could not open <dbdir>", cmd);
+
+  // Refuse to self-reference.
+  if (main.name == upstream.name)
+    return error("refusing to check self as upstream");
+
+  // Check if main is up-to-date.
+  auto existing_entry = main.upstreams.find(upstream.name);
+  if (existing_entry == main.upstreams.end() ||
+      existing_entry->second.num_upstreams !=
+          (long)upstream.upstreams.size() ||
+      existing_entry->second.commits_size != upstream.commits_size_on_open() ||
+      existing_entry->second.svnbase_size != upstream.svnbase_size_on_open()) {
+    fprintf(stderr, "'%s' is not up-to-date with '%s'\n", main.name.c_str(),
+            upstream.name.c_str());
+    return 1;
+  }
+
+  fprintf(stderr, "'%s' is up-to-date with '%s'\n", main.name.c_str(),
+          upstream.name.c_str());
+  return 0;
+}
+
 static int main_dump(const char *cmd, int argc, const char *argv[]) {
   if (argc != 1)
     return usage("dump: extra positional arguments", cmd);
@@ -502,6 +534,7 @@ int main(int argc, const char *argv[]) {
   SUB_MAIN_SVNBASE(lookup);
   SUB_MAIN_SVNBASE(insert);
   SUB_MAIN_IMPL("interleave-commits", interleave_commits);
+  SUB_MAIN_IMPL("check-upstream", check_upstream);
 #undef SUB_MAIN_IMPL
 #undef SUB_MAIN
 #undef SUB_MAIN_SVNBASE

--- a/test/mt/generate/Inputs/cascade.mt-config.in
+++ b/test/mt/generate/Inputs/cascade.mt-config.in
@@ -1,0 +1,12 @@
+# cascade.mt-config
+upstream downstream
+
+repo cask/a file://%t-cask.a
+repo cask/mono file://%t-cask.mono
+repo cask/split file://%t-cask.split
+
+destination splitref cask/split
+destination monorepo cask/mono
+
+generate branch internal/master
+dir internal/master a cask/a/internal

--- a/test/mt/generate/Inputs/check-for-work.mt-config.in
+++ b/test/mt/generate/Inputs/check-for-work.mt-config.in
@@ -1,0 +1,18 @@
+repo a-name file://%t.a
+repo b-name file://%t.b
+repo out/mono file://%t.out.mono
+repo out/split file://%t.out.split
+
+destination splitref out/split
+destination monorepo out/mono
+
+declare-dir a
+declare-dir b
+
+generate branch master
+dir master a a-name/master
+dir master b b-name/master
+
+generate branch other
+dir other a a-name/other
+dir other b b-name/other

--- a/test/mt/generate/Inputs/downstream.mt-config.in
+++ b/test/mt/generate/Inputs/downstream.mt-config.in
@@ -1,0 +1,14 @@
+# downstream.mt-config
+upstream upstream
+
+repo down/a file://%t-down.a
+repo down/b file://%t-down.b
+repo down/mono file://%t-down.mono
+repo down/split file://%t-down.split
+
+destination splitref down/split
+destination monorepo down/mono
+
+generate branch fork/master
+dir fork/master a down/a/fork
+dir fork/master b down/b/fork

--- a/test/mt/generate/Inputs/duplicate-repo-name.mt-config
+++ b/test/mt/generate/Inputs/duplicate-repo-name.mt-config
@@ -1,0 +1,2 @@
+repo a file:///a-1.git
+repo a file:///a-2.git

--- a/test/mt/generate/Inputs/duplicate-repo-url.mt-config
+++ b/test/mt/generate/Inputs/duplicate-repo-url.mt-config
@@ -1,0 +1,2 @@
+repo a1 file:///a.git
+repo a2 file:///a.git

--- a/test/mt/generate/Inputs/duplicate-repo.mt-config
+++ b/test/mt/generate/Inputs/duplicate-repo.mt-config
@@ -1,0 +1,2 @@
+repo a file:///a.git
+repo a file:///a.git

--- a/test/mt/generate/Inputs/generate-splitrefs-prep.mt-config.in
+++ b/test/mt/generate/Inputs/generate-splitrefs-prep.mt-config.in
@@ -1,0 +1,15 @@
+repo a-name file://%t.a
+repo b-name file://%t.b
+repo out/split file://%t.out.split
+repo out/mono file://%t.out.mono
+
+destination splitref out/split
+destination monorepo out/mono
+
+declare-dir a
+declare-dir b
+
+# This is prep to get some objects into the repo.
+generate branch prep
+dir prep a a-name/master
+dir prep b b-name/master

--- a/test/mt/generate/Inputs/list-down1-mapping.mt-config
+++ b/test/mt/generate/Inputs/list-down1-mapping.mt-config
@@ -1,0 +1,4 @@
+upstream list
+
+# Illegal to have a mapping and an upstream.
+generate mapping b-name/master

--- a/test/mt/generate/Inputs/list-down1-redeclare-dir.mt-config
+++ b/test/mt/generate/Inputs/list-down1-redeclare-dir.mt-config
@@ -1,0 +1,4 @@
+upstream list
+
+# Illegal to redeclare a directory.
+declare-dir z

--- a/test/mt/generate/Inputs/list-down1-redeclare-repo.mt-config
+++ b/test/mt/generate/Inputs/list-down1-redeclare-repo.mt-config
@@ -1,0 +1,4 @@
+upstream list
+
+# Illegal to declare the same repo again.
+repo a-name git://a/url

--- a/test/mt/generate/Inputs/list-down1-regenerate-branch.mt-config
+++ b/test/mt/generate/Inputs/list-down1-regenerate-branch.mt-config
@@ -1,0 +1,5 @@
+upstream list
+
+# Illegal to use the same branch name.
+generate branch b2
+dir b2 x a-name/x2

--- a/test/mt/generate/Inputs/list-down1.mt-config
+++ b/test/mt/generate/Inputs/list-down1.mt-config
@@ -1,0 +1,12 @@
+upstream list
+
+repo a2-name git://a2/url
+repo b2-name git://b2/url
+
+declare-dir u
+
+generate branch b4
+dir    b4 x a2-name/x
+dir    b4 u b2-name/u
+dir    b4 z a-name/z2
+repeat b4 b2

--- a/test/mt/generate/Inputs/list-down2-redeclare-dir.mt-config
+++ b/test/mt/generate/Inputs/list-down2-redeclare-dir.mt-config
@@ -1,0 +1,4 @@
+upstream list-down1
+
+# Illegal to redeclare a directory, even when transitive.
+declare-dir z

--- a/test/mt/generate/Inputs/list-down2-redeclare-repo.mt-config
+++ b/test/mt/generate/Inputs/list-down2-redeclare-repo.mt-config
@@ -1,0 +1,4 @@
+upstream list-down1
+
+# Illegal to declare the same repo again, even when transitive.
+repo a-name git://a/url

--- a/test/mt/generate/Inputs/list-down2-regenerate-branch.mt-config
+++ b/test/mt/generate/Inputs/list-down2-regenerate-branch.mt-config
@@ -1,0 +1,5 @@
+upstream list-down1
+
+# Illegal to use the same branch name, even when transitive.
+generate branch b2
+dir b2 x a-name/x2

--- a/test/mt/generate/Inputs/list-down2.mt-config
+++ b/test/mt/generate/Inputs/list-down2.mt-config
@@ -1,0 +1,13 @@
+upstream list-down1
+
+repo a3-name git://a3/url
+
+declare-dir t
+
+generate branch b5
+repeat b5 b4
+dir    b5 t  a3-name/t
+
+generate branch b6
+repeat b6 b2
+dir    b6 x  a3-name/x

--- a/test/mt/generate/Inputs/list-duplicate-upstream-2.mt-config
+++ b/test/mt/generate/Inputs/list-duplicate-upstream-2.mt-config
@@ -1,0 +1,25 @@
+repo a-name git://a/url
+repo b-name git://b/url
+
+declare-dir w
+declare-dir y
+declare-dir z
+declare-dir x
+declare-dir v
+
+upstream upconfig
+
+dir b2 x a-name/x
+dir b2 y b-name/xyz
+dir b1 w b-name/w
+dir b3 z a-name/z
+
+upstream other
+
+repeat b1 b2
+repeat b3 b1
+
+generate mapping a-name/master
+generate branch b2
+generate branch b1
+generate branch b3

--- a/test/mt/generate/Inputs/list-duplicate-upstream.mt-config
+++ b/test/mt/generate/Inputs/list-duplicate-upstream.mt-config
@@ -1,0 +1,24 @@
+upstream upconfig
+upstream other
+
+repo a-name git://a/url
+repo b-name git://b/url
+
+declare-dir w
+declare-dir y
+declare-dir z
+declare-dir x
+declare-dir v
+
+dir b2 x a-name/x
+dir b2 y b-name/xyz
+dir b1 w b-name/w
+dir b3 z a-name/z
+
+repeat b1 b2
+repeat b3 b1
+
+generate mapping a-name/master
+generate branch b2
+generate branch b1
+generate branch b3

--- a/test/mt/generate/Inputs/list-too-many-upstreams.mt-config
+++ b/test/mt/generate/Inputs/list-too-many-upstreams.mt-config
@@ -1,0 +1,4 @@
+upstream list
+
+# Illegal to have two or more upstreams.
+upstream mapping

--- a/test/mt/generate/Inputs/mapping-too-many.mt-config.in
+++ b/test/mt/generate/Inputs/mapping-too-many.mt-config.in
@@ -1,0 +1,13 @@
+repo in1 file://%t-1.in
+repo in2 file://%t-2.in
+repo out/split file://%t.out.split
+repo out/mono file://%t.out.mono
+
+destination splitref out/split
+destination monorepo out/mono
+
+declare-dir a
+declare-dir b
+
+generate mapping in1/master
+generate mapping in2/master

--- a/test/mt/generate/Inputs/mapping.mt-config.in
+++ b/test/mt/generate/Inputs/mapping.mt-config.in
@@ -1,0 +1,11 @@
+repo in file://%t.in
+repo out/split file://%t.out.split
+repo out/mono file://%t.out.mono
+
+destination splitref out/split
+destination monorepo out/mono
+
+declare-dir a
+declare-dir b
+
+generate mapping in/master

--- a/test/mt/generate/Inputs/upstream.mt-config.in
+++ b/test/mt/generate/Inputs/upstream.mt-config.in
@@ -1,0 +1,15 @@
+# upstream.mt-config
+repo up/a file://%t-up.a
+repo up/b file://%t-up.b
+repo up/mono file://%t-up.mono
+repo up/split file://%t-up.split
+
+destination splitref up/split
+destination monorepo up/mono
+
+declare-dir a
+declare-dir b
+
+generate branch master
+dir master a up/a/master
+dir master b up/b/master

--- a/test/mt/generate/cascade.test
+++ b/test/mt/generate/cascade.test
@@ -1,0 +1,74 @@
+RUN: mkrepo %t-up.a
+RUN: mkrepo %t-up.b
+RUN: env ct=1550000001 mkblob %t-up.a 1
+RUN: env ct=1550000002 mkblob %t-up.b 2
+
+RUN: mkrepo %t-down.a
+RUN: mkrepo %t-down.b
+RUN: git -C %t-down.a remote add upstream %t-up.a
+RUN: git -C %t-down.b remote add upstream %t-up.b
+RUN: git -C %t-down.a remote update
+RUN: git -C %t-down.b remote update
+RUN: git -C %t-down.a checkout -b fork upstream/master
+RUN: git -C %t-down.b checkout -b fork upstream/master
+RUN: git -C %t-down.a symbolic-ref HEAD refs/heads/fork
+RUN: git -C %t-down.b symbolic-ref HEAD refs/heads/fork
+RUN: env ct=1550000003 mkblob %t-down.b 3
+RUN: env ct=1550000004 mkblob %t-down.a 4
+
+RUN: mkrepo %t-cask.a
+RUN: git -C %t-cask.a remote add upstream %t-up.a
+RUN: git -C %t-cask.a remote add fork %t-down.a
+RUN: git -C %t-cask.a remote update
+RUN: git -C %t-cask.a checkout -b internal fork/fork
+RUN: git -C %t-cask.a symbolic-ref HEAD refs/heads/internal
+RUN: env ct=1550000005 mkblob %t-cask.a 5
+
+RUN: mkrepo --bare %t-up.split
+RUN: mkrepo --bare %t-up.mono
+RUN: mkrepo --bare %t-down.split
+RUN: mkrepo --bare %t-down.mono
+RUN: mkrepo --bare %t-cask.split
+RUN: mkrepo --bare %t-cask.mono
+RUN: rm -rf %t-mt-configs %t-mt-up.git %t-mt-down.git %t-mt-cask.git
+RUN: mkdir -p %t-mt-configs
+RUN: cat         %S/Inputs/upstream.mt-config.in   | sed -e 's,%%t,%t,' \
+RUN:   | tee %t-mt-configs/upstream.mt-config
+RUN: cat         %S/Inputs/downstream.mt-config.in | sed -e 's,%%t,%t,' \
+RUN:   | tee %t-mt-configs/downstream.mt-config
+RUN: cat         %S/Inputs/cascade.mt-config.in | sed -e 's,%%t,%t,' \
+RUN:   | tee %t-mt-configs/cascade.mt-config
+
+# Generate the cascade.
+RUN: %mtgen --git-dir %t-mt-up.git --config-dir %t-mt-configs \
+RUN:     upstream
+RUN: %mtgen --git-dir %t-mt-down.git --config-dir %t-mt-configs \
+RUN:     downstream
+RUN: %mtgen --git-dir %t-mt-cask.git --config-dir %t-mt-configs \
+RUN:     cascade
+
+# Add new commits to upstream and confirm cascade refuses to generate.  This
+# intentionally bypasses downstream so that the test confirms that the order of
+# the cascade is enforced even when the commit graph skips a level.
+RUN: env ct=1550000006 mkblob %t-up.a 6
+RUN: git -C %t-cask.a remote update
+RUN: env ct=1550000007 mkmerge %t-cask.a 7 upstream/master
+RUN: not %mtgen --git-dir %t-mt-cask.git --config-dir %t-mt-configs \
+RUN:     cascade 2>&1 | grep error: | check-diff %s UPSTREAM %t
+UPSTREAM: error: too many retries for --sync-destinations, giving up
+UPSTREAM: error: upstream 'upstream'   out-of-date
+UPSTREAM: error: upstream 'downstream' out-of-date
+
+# Updating upstream is not sufficient, downstream needs to be updated too.
+RUN: %mtgen --git-dir %t-mt-up.git --config-dir %t-mt-configs \
+RUN:     upstream
+RUN: not %mtgen --git-dir %t-mt-cask.git --config-dir %t-mt-configs \
+RUN:     cascade 2>&1 | grep error: | check-diff %s DOWNSTREAM %t
+DOWNSTREAM: error: too many retries for --sync-destinations, giving up
+DOWNSTREAM: error: upstream 'downstream' out-of-date
+
+# Now it's safe.
+RUN: %mtgen --git-dir %t-mt-down.git --config-dir %t-mt-configs \
+RUN:     downstream
+RUN: %mtgen --git-dir %t-mt-cask.git --config-dir %t-mt-configs \
+RUN:     cascade

--- a/test/mt/generate/check-for-work-mapping.test
+++ b/test/mt/generate/check-for-work-mapping.test
@@ -1,0 +1,38 @@
+
+# Make some commits that look like llvm.org monorepo commits.
+RUN: mkrepo %t.in
+RUN: env     ct=1550000002 mkcommit %t.in --allow-empty -m "llvm-svn: 2"
+RUN: printf                                "some subject\n\nllvm-svn: 4\n" \
+RUN:   | env ct=1550000004 mkcommit %t.in --allow-empty -F -
+RUN: env     ct=1550000005 mkcommit %t.in --allow-empty -m "llvm-svn: 5"
+
+RUN: mkrepo --bare %t.out.split
+RUN: mkrepo --bare %t.out.mono
+RUN: rm -rf %t-mt-repo.git 
+RUN: rm -rf %t-mt-configs
+RUN: mkdir -p %t-mt-configs
+RUN: cat         %S/Inputs/mapping.mt-config.in | sed -e 's,%%t,%t,' \
+RUN:   | tee %t-mt-configs/mapping.mt-config
+
+# Check for work.
+RUN: %mtgen --git-dir %t-mt-repo.git --config-dir %t-mt-configs \
+RUN:     mapping --check-for-work | check-diff %s CHECK %t
+CHECK: work: generate mapping in/master
+RUN: %svn2git dump %t-mt-repo.git/mt-db.checkout/svn2git.db | check-empty
+
+# Run generate and check again.
+RUN: %mtgen --git-dir %t-mt-repo.git --config-dir %t-mt-configs mapping
+RUN: git -C %t-mt-repo.git show-ref | not grep refs/heads
+RUN: number-commits -p IN %t.in master >%t.map
+RUN: %svn2git dump %t-mt-repo.git/mt-db.checkout/svn2git.db \
+RUN:   | apply-commit-numbers %t.map | check-diff %s DUMP %t
+DUMP: r2 IN-1
+DUMP: r4 IN-2
+DUMP: r5 IN-3
+
+# Add work and check it didn't generate anything.
+RUN: env     ct=1550000008 mkcommit %t.in --allow-empty -m "llvm-svn: 8"
+RUN: %mtgen --git-dir %t-mt-repo.git --config-dir %t-mt-configs \
+RUN:     mapping --check-for-work | check-diff %s CHECK %t
+RUN: %svn2git dump %t-mt-repo.git/mt-db.checkout/svn2git.db \
+RUN:   | apply-commit-numbers %t.map | check-diff %s DUMP %t

--- a/test/mt/generate/check-for-work-splitrefs.test
+++ b/test/mt/generate/check-for-work-splitrefs.test
@@ -1,0 +1,57 @@
+RUN: mkrepo %t.a
+RUN: mkrepo %t.b
+RUN: env ct=1550000001 mkblob %t.a 1
+RUN: env ct=1550000002 mkblob %t.b 2
+
+RUN: mkrepo --bare %t.out.split
+RUN: mkrepo --bare %t.out.mono
+RUN: rm -rf %t-mt-repo.git 
+RUN: rm -rf %t-mt-configs
+RUN: mkdir -p %t-mt-configs
+
+# Do some prep work and then swap in the real config.
+RUN: cat         %S/Inputs/generate-splitrefs-prep.mt-config.in \
+RUN:   | sed -e 's,%%t,%t,' \
+RUN:   | tee %t-mt-configs/generate-splitrefs-prep.mt-config
+RUN: cat         %S/Inputs/generate-splitrefs.mt-config.in \
+RUN:   | sed -e 's,%%t,%t,' \
+RUN:   | tee %t-mt-configs/generate-splitrefs-real.mt-config
+RUN: cp %t-mt-configs/generate-splitrefs-prep.mt-config \
+RUN:    %t-mt-configs/generate-splitrefs.mt-config
+RUN: %mtgen --git-dir %t-mt-repo.git --config-dir %t-mt-configs \
+RUN:     generate-splitrefs
+RUN: cp %t-mt-configs/generate-splitrefs-real.mt-config \
+RUN:    %t-mt-configs/generate-splitrefs.mt-config
+
+# Check for work.
+RUN: %mtgen --git-dir %t-mt-repo.git --config-dir %t-mt-configs \
+RUN:     generate-splitrefs --check-for-work | check-diff %s MASTER %t
+MASTER: work: generate splitrefs refs/heads/master
+RUN: git -C %t-mt-repo.git show-ref mt-split | not grep master
+
+# Run generate and check again.
+RUN: %mtgen --git-dir %t-mt-repo.git --config-dir %t-mt-configs \
+RUN:     generate-splitrefs
+RUN: number-commits -p A %t.a master  >%t.map
+RUN: number-commits -p B %t.b master >>%t.map
+RUN: git -C %t-mt-repo.git show-ref mt-split \
+RUN:   | apply-commit-numbers %t.map | grep heads/mt/master \
+RUN:   | check-diff %s CHECK %t
+CHECK: A-1 refs/heads/mt/master/a/mt-split
+CHECK: B-1 refs/heads/mt/master/b/mt-split
+RUN: %mtgen --git-dir %t-mt-repo.git --config-dir %t-mt-configs \
+RUN:     generate-splitrefs --check-for-work | check-empty
+
+# Create more work and repeat the prep.
+RUN: env ct=1550000003 mkblob %t.a 3
+RUN: env ct=1550000004 mkblob %t.b 4
+RUN: cp %t-mt-configs/generate-splitrefs-prep.mt-config \
+RUN:    %t-mt-configs/generate-splitrefs.mt-config
+RUN: %mtgen --git-dir %t-mt-repo.git --config-dir %t-mt-configs \
+RUN:     generate-splitrefs
+RUN: cp %t-mt-configs/generate-splitrefs-real.mt-config \
+RUN:    %t-mt-configs/generate-splitrefs.mt-config
+
+# Check again.
+RUN: %mtgen --git-dir %t-mt-repo.git --config-dir %t-mt-configs \
+RUN:     generate-splitrefs --check-for-work | check-diff %s MASTER %t

--- a/test/mt/generate/check-for-work.test
+++ b/test/mt/generate/check-for-work.test
@@ -1,0 +1,42 @@
+RUN: mkrepo %t.a
+RUN: mkrepo %t.b
+RUN: env ct=1550000001 mkblob %t.a 1
+RUN: env ct=1550000002 mkblob %t.b 2
+RUN: git -C %t.a branch other
+RUN: git -C %t.b branch other
+RUN: git -C %t.a checkout other
+RUN: git -C %t.b checkout other
+RUN: env ct=1550000003 mkblob %t.a 3
+
+RUN: mkrepo --bare %t.out.split
+RUN: mkrepo --bare %t.out.mono
+RUN: rm -rf %t-mt-repo.git 
+RUN: rm -rf %t-mt-configs
+RUN: mkdir -p %t-mt-configs
+RUN: cat         %S/Inputs/check-for-work.mt-config.in | sed -e 's,%%t,%t,' \
+RUN:   | tee %t-mt-configs/check-for-work.mt-config
+
+# Check for work.
+RUN: %mtgen --git-dir %t-mt-repo.git --config-dir %t-mt-configs check-for-work \
+RUN:     --check-for-work | check-diff %s MASTER %t
+MASTER: work: generate branch refs/heads/master
+RUN: not git -C %t-mt-repo.git show-ref refs/heads/master | check-empty
+
+# Run generate and check again.
+RUN: %mtgen --git-dir %t-mt-repo.git --config-dir %t-mt-configs check-for-work
+RUN: %mtgen --git-dir %t-mt-repo.git --config-dir %t-mt-configs check-for-work \
+RUN:     --check-for-work | check-empty
+
+# Create work in other.
+RUN: env ct=1550000004 mkblob %t.b 4
+RUN: %mtgen --git-dir %t-mt-repo.git --config-dir %t-mt-configs \
+RUN:     check-for-work --check-for-work | check-diff %s OTHER %t
+OTHER: work: generate branch refs/heads/other
+
+# Create more work in master.
+RUN: git -C %t.a checkout master
+RUN: git -C %t.b checkout master
+RUN: env ct=1550000005 mkblob %t.a 5
+RUN: env ct=1550000006 mkblob %t.b 6
+RUN: %mtgen --git-dir %t-mt-repo.git --config-dir %t-mt-configs \
+RUN:     check-for-work --check-for-work | check-diff %s MASTER %t

--- a/test/mt/generate/downstream.test
+++ b/test/mt/generate/downstream.test
@@ -1,0 +1,52 @@
+RUN: mkrepo %t-up.a
+RUN: mkrepo %t-up.b
+RUN: mkrepo %t-down.a
+RUN: mkrepo %t-down.b
+RUN: env ct=1550000001 mkblob %t-up.a 1
+RUN: env ct=1550000002 mkblob %t-up.b 2
+
+RUN: git -C %t-down.a remote add upstream %t-up.a
+RUN: git -C %t-down.b remote add upstream %t-up.b
+RUN: git -C %t-down.a remote update
+RUN: git -C %t-down.b remote update
+RUN: git -C %t-down.a checkout -b fork upstream/master
+RUN: git -C %t-down.b checkout -b fork upstream/master
+RUN: git -C %t-down.a symbolic-ref HEAD refs/heads/fork
+RUN: git -C %t-down.b symbolic-ref HEAD refs/heads/fork
+RUN: env ct=1550000003 mkblob %t-down.b 3
+RUN: env ct=1550000004 mkblob %t-down.a 4
+
+RUN: mkrepo --bare %t-up.split
+RUN: mkrepo --bare %t-up.mono
+RUN: mkrepo --bare %t-down.split
+RUN: mkrepo --bare %t-down.mono
+RUN: rm -rf %t-mt-configs %t-mt-up.git %t-mt-down.git
+RUN: mkdir -p %t-mt-configs
+RUN: cat         %S/Inputs/upstream.mt-config.in   | sed -e 's,%%t,%t,' \
+RUN:   | tee %t-mt-configs/upstream.mt-config
+RUN: cat         %S/Inputs/downstream.mt-config.in | sed -e 's,%%t,%t,' \
+RUN:   | tee %t-mt-configs/downstream.mt-config
+
+# Try generating downstream.  This should fail, since there are missing
+# commits from upstream.
+RUN: not %mtgen --git-dir %t-mt-down.git --config-dir %t-mt-configs \
+RUN:     downstream 2>&1 | grep error: | check-diff %s OUT-OF-DATE %t
+OUT-OF-DATE: error: too many retries for --sync-destinations, giving up
+OUT-OF-DATE: error: upstream 'upstream' out-of-date
+
+# Try again after generating the upstream.
+RUN: %mtgen --git-dir %t-mt-up.git --config-dir %t-mt-configs \
+RUN:     upstream
+RUN: %mtgen --git-dir %t-mt-down.git --config-dir %t-mt-configs \
+RUN:     downstream
+
+# Add new commits and repeat.
+RUN: env ct=1550000005 mkblob %t-up.a 5
+RUN: git -C %t-down.a remote update
+RUN: env ct=1550000006 mkmerge %t-down.a 6 upstream/master
+RUN: not %mtgen --git-dir %t-mt-down.git --config-dir %t-mt-configs \
+RUN:     downstream 2>&1 | grep error: | check-diff %s OUT-OF-DATE %t
+RUN: %mtgen --git-dir %t-mt-up.git --config-dir %t-mt-configs \
+RUN:     upstream
+RUN: %mtgen --git-dir %t-mt-down.git --config-dir %t-mt-configs \
+RUN:     downstream

--- a/test/mt/generate/duplicate-repo.test
+++ b/test/mt/generate/duplicate-repo.test
@@ -1,0 +1,10 @@
+RUN: not %mtgen --git-dir %t-mt-repo.git --config-dir %S/Inputs \
+RUN:     duplicate-repo 2>&1 | check-diff %s NAME %t
+RUN: not %mtgen --git-dir %t-mt-repo.git --config-dir %S/Inputs \
+RUN:     duplicate-repo-name 2>&1 | check-diff %s NAME %t
+
+RUN: not %mtgen --git-dir %t-mt-repo.git --config-dir %S/Inputs \
+RUN:     duplicate-repo-url 2>&1 | check-diff %s URL %t
+
+NAME: error: duplicate repo name 'a'
+URL:  error: duplicate repo url 'file:///a.git'

--- a/test/mt/generate/list-actions.test
+++ b/test/mt/generate/list-actions.test
@@ -3,3 +3,10 @@ ACTIONS: mapping a-name/master
 ACTIONS: branch b2
 ACTIONS: branch b1
 ACTIONS: branch b3
+
+RUN: %mtgen list-down1 --list-actions | check-diff %s DOWN1 %t
+DOWN1: branch b4
+
+RUN: %mtgen list-down2 --list-actions | check-diff %s DOWN2 %t
+DOWN2: branch b5
+DOWN2: branch b6

--- a/test/mt/generate/list-branches.test
+++ b/test/mt/generate/list-branches.test
@@ -2,3 +2,24 @@ RUN: %mtgen list --list-branches | check-diff %s BRANCHES %t
 BRANCHES: b1
 BRANCHES: b2
 BRANCHES: b3
+
+RUN: %mtgen list-down1 --list-branches | check-diff %s DOWN1 %t
+DOWN1: b4
+
+RUN: %mtgen list-down1 --list-merged-branches | check-diff %s DOWN1-MERGED %t
+DOWN1-MERGED: b1
+DOWN1-MERGED: b2
+DOWN1-MERGED: b3
+DOWN1-MERGED: b4
+
+RUN: %mtgen list-down2 --list-branches | check-diff %s DOWN2 %t
+DOWN2: b5
+DOWN2: b6
+
+RUN: %mtgen list-down2 --list-merged-branches | check-diff %s DOWN2-MERGED %t
+DOWN2-MERGED: b1
+DOWN2-MERGED: b2
+DOWN2-MERGED: b3
+DOWN2-MERGED: b4
+DOWN2-MERGED: b5
+DOWN2-MERGED: b6

--- a/test/mt/generate/list-dirs-for-branch-downstream.test
+++ b/test/mt/generate/list-dirs-for-branch-downstream.test
@@ -1,0 +1,94 @@
+RUN: %mtgen list-down1 --list-active-dirs=b3 | check-diff %s ACTIVE-DIRS-B3 %t
+RUN: %mtgen list-down1 --list-repeat-dirs=b3 | check-diff %s REPEAT-DIRS-B3 %t
+RUN: %mtgen list-down1 --list-inactive-dirs=b3 \
+RUN:   | check-diff %s INACTIVE-DIRS-B3 %t
+RUN: %mtgen list-down1 --list-active-refdirs=b3 \
+RUN:   | check-diff %s ACTIVE-REFDIRS-B3 %t
+RUN: %mtgen list-down1 --list-repeat-refdirs=b3 \
+RUN:   | check-diff %s REPEAT-REFDIRS-B3 %t
+RUN: %mtgen list-down1 --list-inactive-refdirs=b3 \
+RUN:   | check-diff %s INACTIVE-REFDIRS-B3 %t
+RUN: %mtgen list-down1 --list-all-refdirs=b3 | check-diff %s ALL-REFDIRS-B3 %t
+ACTIVE-DIRS-B3: z
+ACTIVE-REFDIRS-B3: a-name/z:z
+REPEAT-DIRS-B3: w
+REPEAT-DIRS-B3: x
+REPEAT-DIRS-B3: y
+REPEAT-REFDIRS-B3: %b1:w
+REPEAT-REFDIRS-B3: %b1:x
+REPEAT-REFDIRS-B3: %b1:y
+INACTIVE-DIRS-B3: u
+INACTIVE-DIRS-B3: v
+INACTIVE-REFDIRS-B3: -:u
+INACTIVE-REFDIRS-B3: -:v
+ALL-REFDIRS-B3: -:u
+ALL-REFDIRS-B3: -:v
+ALL-REFDIRS-B3: %b1:w
+ALL-REFDIRS-B3: %b1:x
+ALL-REFDIRS-B3: %b1:y
+ALL-REFDIRS-B3: a-name/z:z
+
+RUN: %mtgen list-down1 --list-active-dirs=b4 | check-diff %s ACTIVE-DIRS-B4 %t
+RUN: %mtgen list-down1 --list-repeat-dirs=b4 | check-diff %s REPEAT-DIRS-B4 %t
+RUN: %mtgen list-down1 --list-inactive-dirs=b4 \
+RUN:   | check-diff %s INACTIVE-DIRS-B4 %t
+RUN: %mtgen list-down1 --list-active-refdirs=b4 \
+RUN:   | check-diff %s ACTIVE-REFDIRS-B4 %t
+RUN: %mtgen list-down1 --list-repeat-refdirs=b4 \
+RUN:   | check-diff %s REPEAT-REFDIRS-B4 %t
+RUN: %mtgen list-down1 --list-inactive-refdirs=b4 \
+RUN:   | check-diff %s INACTIVE-REFDIRS-B4 %t
+RUN: %mtgen list-down1 --list-all-refdirs=b4 | check-diff %s ALL-REFDIRS-B4 %t
+
+ACTIVE-DIRS-B4: u
+ACTIVE-DIRS-B4: x
+ACTIVE-DIRS-B4: z
+ACTIVE-REFDIRS-B4: b2-name/u:u
+ACTIVE-REFDIRS-B4: a2-name/x:x
+ACTIVE-REFDIRS-B4: a-name/z2:z
+REPEAT-DIRS-B4: y
+REPEAT-REFDIRS-B4: %b2:y
+INACTIVE-DIRS-B4: v
+INACTIVE-DIRS-B4: w
+INACTIVE-REFDIRS-B4: -:v
+INACTIVE-REFDIRS-B4: -:w
+ALL-REFDIRS-B4: b2-name/u:u
+ALL-REFDIRS-B4: -:v
+ALL-REFDIRS-B4: -:w
+ALL-REFDIRS-B4: a2-name/x:x
+ALL-REFDIRS-B4: %b2:y
+ALL-REFDIRS-B4: a-name/z2:z
+
+RUN: %mtgen list-down2 --list-active-dirs=b6 | check-diff %s ACTIVE-DIRS-B6 %t
+RUN: %mtgen list-down2 --list-repeat-dirs=b6 | check-diff %s REPEAT-DIRS-B6 %t
+RUN: %mtgen list-down2 --list-inactive-dirs=b6 \
+RUN:   | check-diff %s INACTIVE-DIRS-B6 %t
+RUN: %mtgen list-down2 --list-active-refdirs=b6 \
+RUN:   | check-diff %s ACTIVE-REFDIRS-B6 %t
+RUN: %mtgen list-down2 --list-repeat-refdirs=b6 \
+RUN:   | check-diff %s REPEAT-REFDIRS-B6 %t
+RUN: %mtgen list-down2 --list-inactive-refdirs=b6 \
+RUN:   | check-diff %s INACTIVE-REFDIRS-B6 %t
+RUN: %mtgen list-down2 --list-all-refdirs=b6 | check-diff %s ALL-REFDIRS-B6 %t
+
+ACTIVE-DIRS-B6: x
+ACTIVE-REFDIRS-B6: a3-name/x:x
+REPEAT-DIRS-B6: y
+REPEAT-REFDIRS-B6: %b2:y
+INACTIVE-DIRS-B6: t
+INACTIVE-DIRS-B6: u
+INACTIVE-DIRS-B6: v
+INACTIVE-DIRS-B6: w
+INACTIVE-DIRS-B6: z
+INACTIVE-REFDIRS-B6: -:t
+INACTIVE-REFDIRS-B6: -:u
+INACTIVE-REFDIRS-B6: -:v
+INACTIVE-REFDIRS-B6: -:w
+INACTIVE-REFDIRS-B6: -:z
+ALL-REFDIRS-B6: -:t
+ALL-REFDIRS-B6: -:u
+ALL-REFDIRS-B6: -:v
+ALL-REFDIRS-B6: -:w
+ALL-REFDIRS-B6: a3-name/x:x
+ALL-REFDIRS-B6: %b2:y
+ALL-REFDIRS-B6: -:z

--- a/test/mt/generate/list-dirs-for-branch-repeat-two-layers.test
+++ b/test/mt/generate/list-dirs-for-branch-repeat-two-layers.test
@@ -5,7 +5,8 @@ RUN: %mtgen list --list-repeat-dirs=b3 | check-diff %s REPEAT-DIRS-B3 %t
 RUN: %mtgen list --list-inactive-dirs=b3 | check-diff %s INACTIVE-DIRS-B3 %t
 RUN: %mtgen list --list-active-refdirs=b3 | check-diff %s ACTIVE-REFDIRS-B3 %t
 RUN: %mtgen list --list-repeat-refdirs=b3 | check-diff %s REPEAT-REFDIRS-B3 %t
-RUN: %mtgen list --list-inactive-refdirs=b3 | check-diff %s INACTIVE-REFDIRS-B3 %t
+RUN: %mtgen list --list-inactive-refdirs=b3 \
+RUN:   | check-diff %s INACTIVE-REFDIRS-B3 %t
 RUN: %mtgen list --list-all-refdirs=b3 | check-diff %s ALL-REFDIRS-B3 %t
 ACTIVE-DIRS-B3: z
 ACTIVE-REFDIRS-B3: a-name/z:z

--- a/test/mt/generate/list-dirs.test
+++ b/test/mt/generate/list-dirs.test
@@ -4,3 +4,20 @@ DIRS: w
 DIRS: x
 DIRS: y
 DIRS: z
+
+RUN: %mtgen list-down1 --list-dirs | check-diff %s DOWN1 %t
+DOWN1: u
+DOWN1: v
+DOWN1: w
+DOWN1: x
+DOWN1: y
+DOWN1: z
+
+RUN: %mtgen list-down2 --list-dirs | check-diff %s DOWN2 %t
+DOWN2: t
+DOWN2: u
+DOWN2: v
+DOWN2: w
+DOWN2: x
+DOWN2: y
+DOWN2: z

--- a/test/mt/generate/list-down1-invalid.test
+++ b/test/mt/generate/list-down1-invalid.test
@@ -1,0 +1,15 @@
+RUN: not %mtgen list-down1-mapping --validate-mt-config 2>&1 \
+RUN:   | check-diff %s MAPPING %t
+MAPPING: error: cannot have upstream 'list' and mapping 'b-name/master'
+
+RUN: not %mtgen list-down1-redeclare-dir --validate-mt-config 2>&1 \
+RUN:   | check-diff %s REDECLARE-DIR %t
+REDECLARE-DIR: error: re-declared directory 'z'
+
+RUN: not %mtgen list-down1-redeclare-repo --validate-mt-config 2>&1 \
+RUN:   | check-diff %s REDECLARE-REPO %t
+REDECLARE-REPO: error: duplicate repo name 'a-name'
+
+RUN: not %mtgen list-down1-regenerate-branch --validate-mt-config 2>&1 \
+RUN:   | check-diff %s REGENERATE-BRANCH %t
+REGENERATE-BRANCH: error: duplicate branch 'b2'

--- a/test/mt/generate/list-down2-invalid.test
+++ b/test/mt/generate/list-down2-invalid.test
@@ -1,0 +1,11 @@
+RUN: not %mtgen list-down2-redeclare-dir --validate-mt-config 2>&1 \
+RUN:   | check-diff %s REDECLARE-DIR %t
+REDECLARE-DIR: error: re-declared directory 'z'
+
+RUN: not %mtgen list-down2-redeclare-repo --validate-mt-config 2>&1 \
+RUN:   | check-diff %s REDECLARE-REPO %t
+REDECLARE-REPO: error: duplicate repo name 'a-name'
+
+RUN: not %mtgen list-down2-regenerate-branch --validate-mt-config 2>&1 \
+RUN:   | check-diff %s REGENERATE-BRANCH %t
+REGENERATE-BRANCH: error: duplicate branch 'b2'

--- a/test/mt/generate/list-repeat.test
+++ b/test/mt/generate/list-repeat.test
@@ -3,3 +3,6 @@ RUN: %mtgen list --list-repeat b1 | check-diff %s B1 %t
 RUN: %mtgen list --list-repeat b3 | check-diff %s B3 %t
 B1: b2
 B3: b1
+
+RUN: %mtgen list-down1 --list-repeat b1 | check-diff %s B1 %t
+RUN: %mtgen list-down2 --list-repeat b1 | check-diff %s B1 %t

--- a/test/mt/generate/list-repos.test
+++ b/test/mt/generate/list-repos.test
@@ -1,3 +1,16 @@
 RUN: %mtgen list --list-repos | check-diff %s REPOS %t
 REPOS: a-name git://a/url
 REPOS: b-name git://b/url
+
+RUN: %mtgen list-down1 --list-repos | check-diff %s DOWN1 %t
+DOWN1: a-name  git://a/url
+DOWN1: b-name  git://b/url
+DOWN1: a2-name git://a2/url
+DOWN1: b2-name git://b2/url
+
+RUN: %mtgen list-down2 --list-repos | check-diff %s DOWN2 %t
+DOWN2: a-name  git://a/url
+DOWN2: b-name  git://b/url
+DOWN2: a2-name git://a2/url
+DOWN2: b2-name git://b2/url
+DOWN2: a3-name git://a3/url

--- a/test/mt/generate/list-too-many-upstreams.test
+++ b/test/mt/generate/list-too-many-upstreams.test
@@ -1,0 +1,5 @@
+RUN: not %mtgen list-too-many-upstreams | check-empty
+RUN: not %mtgen list-too-many-upstreams 2>&1 | check-diff %s CHECK %t
+CHECK: error: second upstream declaration not supported
+CHECK: note: 1st upstream: list
+CHECK: note: 2nd upstream: mapping

--- a/test/mt/generate/lit.local.cfg
+++ b/test/mt/generate/lit.local.cfg
@@ -1,3 +1,3 @@
 config.substitutions.append(('%mtgen',
-    'git apple-llvm mt generate --config-dir=' +
+    'git apple-llvm mt generate --sync-destinations-retries=0 --config-dir=' +
     os.path.join(os.path.dirname(__file__), 'Inputs')))

--- a/test/mt/generate/mapping-too-many.test
+++ b/test/mt/generate/mapping-too-many.test
@@ -1,0 +1,16 @@
+# Make some commits that look like llvm.org monorepo commits.
+RUN: mkrepo %t-1.in
+RUN: mkrepo %t-2.in
+RUN: env ct=1550000001 mkcommit %t-1.in --allow-empty -m "llvm-svn: 1"
+RUN: env ct=1550000002 mkcommit %t-2.in --allow-empty -m "llvm-svn: 2"
+
+RUN: mkrepo --bare %t.out.split
+RUN: mkrepo --bare %t.out.mono
+RUN: rm -rf %t-mt-repo.git 
+RUN: rm -rf %t-mt-configs
+RUN: mkdir -p %t-mt-configs
+RUN: cat         %S/Inputs/mapping-too-many.mt-config.in | sed -e 's,%%t,%t,' \
+RUN:   | tee %t-mt-configs/mapping-too-many.mt-config
+RUN: not %mtgen --git-dir %t-mt-repo.git --config-dir %t-mt-configs \
+RUN:     mapping-too-many 2>&1 | grep error: | check-diff %s CHECK %t
+CHECK: error: too many mappings: 'in1/master' and 'in2/master'

--- a/test/mt/generate/mapping.test
+++ b/test/mt/generate/mapping.test
@@ -1,0 +1,33 @@
+# Make some commits that look like llvm.org monorepo commits.
+RUN: mkrepo %t.in
+RUN: env     ct=1550000002 mkcommit %t.in --allow-empty -m "llvm-svn: 2"
+RUN: printf                                "some subject\n\nllvm-svn: 4\n" \
+RUN:   | env ct=1550000004 mkcommit %t.in --allow-empty -F -
+RUN: env     ct=1550000005 mkcommit %t.in --allow-empty -m "llvm-svn: 5"
+
+RUN: mkrepo --bare %t.out.split
+RUN: mkrepo --bare %t.out.mono
+RUN: rm -rf %t-mt-repo.git 
+RUN: rm -rf %t-mt-configs
+RUN: mkdir -p %t-mt-configs
+RUN: cat         %S/Inputs/mapping.mt-config.in | sed -e 's,%%t,%t,' \
+RUN:   | tee %t-mt-configs/mapping.mt-config
+RUN: %mtgen --git-dir %t-mt-repo.git --config-dir %t-mt-configs mapping
+RUN: git -C %t-mt-repo.git show-ref | not grep refs/heads
+RUN: number-commits -p IN %t.in master >%t.map
+RUN: %svn2git dump %t-mt-repo.git/mt-db.checkout/svn2git.db \
+RUN:   | apply-commit-numbers %t.map | check-diff %s CHECK-3 %t
+CHECK-3: r2 IN-1
+CHECK-3: r4 IN-2
+CHECK-3: r5 IN-3
+
+# Do some more owrk.
+RUN: env     ct=1550000008 mkcommit %t.in --allow-empty -m "llvm-svn: 8"
+RUN: %mtgen --git-dir %t-mt-repo.git --config-dir %t-mt-configs mapping
+RUN: number-commits -p SECOND-RUN %t.in master^..master >>%t.map
+RUN: %svn2git dump %t-mt-repo.git/mt-db.checkout/svn2git.db \
+RUN:   | apply-commit-numbers %t.map | check-diff %s CHECK-4 %t
+CHECK-4: r2 IN-1
+CHECK-4: r4 IN-2
+CHECK-4: r5 IN-3
+CHECK-4: r8 SECOND-RUN-1

--- a/test/mt/generate/show-upstream-duplicate.test
+++ b/test/mt/generate/show-upstream-duplicate.test
@@ -1,0 +1,7 @@
+RUN: not %mtgen list-duplicate-upstream --show-upstream 2>&1 \
+RUN:  | check-diff %s CHECK %t
+RUN: not %mtgen list-duplicate-upstream-2 --show-upstream 2>&1 \
+RUN:  | check-diff %s CHECK %t
+CHECK: error: second upstream declaration not supported
+CHECK: note: 1st upstream: upconfig
+CHECK: note: 2nd upstream: other

--- a/test/mt/generate/show-upstream.test
+++ b/test/mt/generate/show-upstream.test
@@ -1,0 +1,6 @@
+RUN: %mtgen list --show-upstream | check-empty
+CHECK: upconfig
+RUN: %mtgen list-down1 --show-upstream | check-diff %s DOWN1 %t
+DOWN1: list
+RUN: %mtgen list-down2 --show-upstream | check-diff %s DOWN2 %t
+DOWN2: list-down1

--- a/test/split2mono/insert-upstream-cascade.test
+++ b/test/split2mono/insert-upstream-cascade.test
@@ -3,6 +3,17 @@ RUN:        %t-both2.db %t-left.db %t-right.db %t-root.db
 RUN: mkdir  %t-left1.db %t-left2.db %t-right1.db %t-right2.db %t-both1.db \
 RUN:        %t-both2.db %t-left.db %t-right.db %t-root.db
 
+# This test sets up dbs for the following "upstream" graph:
+#
+#        left1 ---> both1 <---- right1
+#          |          |           |
+#         \|/        \|/         \|/
+#        left  ---> root  <---- right
+#         /|\        /|\         /|\
+#          |          |           |
+#        left2 ---> both2 <---- right2
+#
+# where upstream merges are allowed to happen in that order.
 RUN: %split2mono create %t-left1.db  left1
 RUN: %split2mono create %t-left2.db  left2
 RUN: %split2mono create %t-right1.db right1
@@ -22,6 +33,20 @@ LEFT2:  name: left2
 RIGHT1: name: right1
 RIGHT2: name: right2
 
+# Check whether check-upstream looks at the upstreams.  Always checking if
+# "root" is up-to-date with "left", do the following merges:
+# - root <= left  (root     up-to-date with left)
+# - left <= left1 (root not up-to-date with left)
+# - root <= left  (root     up-to-date with left)
+RUN: %split2mono           upstream %t-root.db  %t-left.db
+RUN: %split2mono     check-upstream %t-root.db  %t-left.db
+RUN: %split2mono           upstream %t-left.db  %t-left1.db
+RUN: not %split2mono check-upstream %t-root.db  %t-left.db
+RUN: %split2mono           upstream %t-root.db  %t-left.db
+RUN: %split2mono     check-upstream %t-root.db  %t-left.db
+
+# Check that cascading merges work correctly.
+RUN: %split2mono upstream %t-left.db  %t-left1.db
 RUN: %split2mono upstream %t-left.db  %t-left1.db
 RUN: %split2mono upstream %t-both1.db %t-left1.db
 RUN: %split2mono upstream %t-both1.db %t-right1.db

--- a/test/split2mono/insert-upstream.test
+++ b/test/split2mono/insert-upstream.test
@@ -6,7 +6,13 @@ RUN:                             9876543210abcdef0123456789abcdef01234567
 RUN: %split2mono create %t-down.db down
 RUN: not %split2mono upstream %t-down.db %t-down.db
 RUN: not %split2mono upstream %t-up.db   %t-up.db
+RUN: not %split2mono check-upstream %t-down.db %t-up.db 2>&1 \
+RUN:   | check-diff %s OUT-OF-DATE %t
 RUN: %split2mono upstream %t-down.db %t-up.db
+RUN: %split2mono check-upstream %t-down.db %t-up.db 2>&1 \
+RUN:   | check-diff %s UP-TO-DATE %t
+OUT-OF-DATE: 'down' is not up-to-date with 'up'
+UP-TO-DATE:  'down' is     up-to-date with 'up'
 
 RUN: cat %t-up.db/upstreams | check-diff %s UP-UPSTREAMS %t
 UP-UPSTREAMS: name: up
@@ -46,7 +52,11 @@ RUN: %split2mono insert %t-up.db 3123456789abcdef0123456789abcdef01234567 \
 RUN:                             3876543210abcdef0123456789abcdef01234567
 RUN: %split2mono insert-svnbase %t-up.db 3123456789abcdef0123456789abcdef01234567 \
 RUN:                                     123
+RUN: not %split2mono check-upstream %t-down.db %t-up.db 2>&1 \
+RUN:   | check-diff %s OUT-OF-DATE %t
 RUN: %split2mono upstream %t-down.db %t-up.db
+RUN: %split2mono check-upstream %t-down.db %t-up.db 2>&1 \
+RUN:   | check-diff %s UP-TO-DATE %t
 RUN: cat %t-down.db/upstreams | check-diff %s UPSTREAMS-SVNBASE %t
 UPSTREAMS-SVNBASE: name: down
 UPSTREAMS-SVNBASE: upstream: up num-upstreams=0 commits-size=2 svnbase-size=1


### PR DESCRIPTION
Includes a couple of new command-line options used to avoid accidentally
translating an upstream commit in a downstream config:

- `split2mono` has a new `check-upstream` command.
- `generate --check-for-work` prints to stdout iff there's work to do.
- `generate --sync-destinations` syncs destination remotes (through
  cascading upstreams) until there's no work to do