### PR TITLE
split2mono: Strengthen heuristic for detecting upstream git-svn commits

### DIFF
--- a/docs/ContributingToTools.md
+++ b/docs/ContributingToTools.md
@@ -40,6 +40,8 @@ For test suites that use `pytest`, add the name of the subdirectory to the
 - `apply-commit-numbers <map>`: filter input using map from `number-commits`.
 - `mkrepo [--bare] <repo>`: create a git repository.
 - `mkblob <repo> <blob>`: create and commit a blob with the given name.
+- `mkblob-svn [options] rev [msg...]`: create and commit blobs in a way that
+  mimics SVN commits in either (or both) git-svn and llvm style.
 - `mkrange <repo> <first> <last>`: run `mkblob.sh` on `{<first>..<last>}` in
   sequence.
 - `mkmerge <repo> <id> <args>...`: create a merge commit from `<args>` using

--- a/src/Programs.mk
+++ b/src/Programs.mk
@@ -8,7 +8,7 @@ sources := $(wildcard $S*.cpp)
 programs := $(patsubst $S%.cpp,$D/%,$(sources))
 
 $(programs): $D/%: $S%.cpp $(headers) $SPrograms.mk
-	mkdir -p "$(@D)" && clang -g -O2 -std=c++17 -lc++ -Wall -Wextra -o "$@" $<
+	mkdir -p "$(@D)" && clang -O2 -std=c++17 -lc++ -Wall -Wextra -o "$@" $<
 
 .PHONY: programs clean-programs
 programs: $(programs) ;

--- a/src/split2mono.cpp
+++ b/src/split2mono.cpp
@@ -371,8 +371,7 @@ static int main_check_upstream(const char *cmd, int argc, const char *argv[]) {
   // Check if main is up-to-date.
   auto existing_entry = main.upstreams.find(upstream.name);
   if (existing_entry == main.upstreams.end() ||
-      existing_entry->second.num_upstreams !=
-          (long)upstream.upstreams.size() ||
+      existing_entry->second.num_upstreams != (long)upstream.upstreams.size() ||
       existing_entry->second.commits_size != upstream.commits_size_on_open() ||
       existing_entry->second.svnbase_size != upstream.svnbase_size_on_open()) {
     fprintf(stderr, "'%s' is not up-to-date with '%s'\n", main.name.c_str(),

--- a/test/bin/mkblob-svn
+++ b/test/bin/mkblob-svn
@@ -1,0 +1,125 @@
+#!/bin/bash
+
+. "$(dirname "$0")"/init.sh
+
+usage() {
+    printf "%s\n" \
+        "usage: mkblob-svn [options] rev [msg...]"                              \
+        "  -b blob        name/content of blob"                                 \
+        "                 * defaults to rev"                                    \
+        "  -d dir         directory/project name for monorepo and git-svn-id"   \
+        "                 * optional if -s/-m specify explicitly"               \
+        "  -s repo[:dir]  split repo, with 'git-svn-id:' trailers"              \
+        "                 * optional dir overrides -d for trailers"             \
+        "  -m repo[:dir]  monorepo, with 'llvm-svn:' trailers"                  \
+        "                 * optional dir overrides -d for monorepo paths"       \
+        "                 * use repo:- for root"                                \
+        "  -t key=value   trailers"                                             \
+        "                 * can be specified multiple times"                    \
+        "                 * note: 'git-svn-id:' and 'llvm-svn:' are implied"    \
+        "  msg...         commit message, excluding trailers"                   \
+        "                 * default based on rev"                               \
+        "                 * multiple positional arguments appended"             \
+        "                   and newline-separated"                              \
+        "                 * implied empty line between first and second arg to" \
+        "                   create subject"
+}
+
+main() {
+    if [ $# -eq 0 ]; then
+        usage >&2
+        exit 1
+    fi
+
+    local blob rev dir split mono lines=() trailers=() pos=0
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            -h|--help) usage; exit 0;;
+            -d) dir="$2";                                     shift 2;;
+            -b) blob="$2";                                    shift 2;;
+            -s) split="$2";                                   shift 2;;
+            -m) mono="$2";                                    shift 2;;
+            -t) trailers=( "${trailers[@]}" --trailer "$2" ); shift 2;;
+            -*) error "unknown option $1";;
+            *)
+                case $pos in
+                    0) rev="$1";;
+                    2) lines=( "${lines[@]}" "" "$1" );;
+                    *) lines=( "${lines[@]}" "$1" );;
+                esac
+                pos=$(( $pos + 1 ))
+                shift;;
+        esac
+    done
+
+    [ $pos -ge 1 ] || error "missing revision; see --help"
+    [ "$rev" -gt 0 ] 2>/dev/null || error "invalid revision '$rev'"
+
+    blob="${blob:-$rev}"
+    [ $pos -gt 1 ] || lines=( "mkblob-svn: r$rev" "" "added the blob '$blob'" )
+
+    get_repo() { printf "%s" "${1%:*}"; }
+    get_dir() {
+        local extracted="${1##*:}"
+        if [ "$extracted" = "$1" ]; then
+            printf "%s" "$dir"
+        else
+            printf "%s" "$extracted"
+        fi
+    }
+
+    local splitrepo="$(get_repo "$split")"
+    local monorepo="$(get_repo "$mono")"
+    local splitdir="$(get_dir "$split")"
+    local monodir="$(get_dir "$mono")"
+    [ -n "$splitrepo" ] || [ -n "$monorepo" ] ||
+        error "at least one of '-s' and '-m' required"
+
+    validate "-m $mono" "$monorepo" "$monodir" "$monodir"
+    validate "-s $split" "$splitrepo" "$splitdir"
+
+    [ -z "$mono" ]  ||
+        make_blob llvm-svn:$rev "$monorepo" "$monodir"
+    [ -z "$split" ] ||
+        make_blob git-svn-id:"$(gitsvntag "$splitdir" $rev)" "$splitrepo"
+}
+
+validate() {
+    local relative file spelling="$1" repo="$2" dir="$3" subdir="$4"
+    [ -n "$repo" ] || return 0
+    setup_file || error "failed to validate '$spelling'"
+
+    [ -d "$repo" ] || error "cannot find repo for '$spelling'"
+    [ -d "$repo/.git" ] || error "invalid repo for '$spelling'"
+    [ -n "$dir" ] || error "no implied dir for '$spelling'"
+    [ ! -e "$file" ] || error "blob '$blob' already exists for '$spelling'"
+}
+
+gitsvntag() {
+    printf "https://llvm.org/svn/llvm-project/%s/trunk@%s %s\n" \
+        "$1" "$2" "91177308-0d34-0410-b5e6-96231b3b80d8"
+}
+
+setup_file() {
+    [ -n "$repo" ] || printf "internal-error: no value for '\$repo'" >&2
+    if [ -z "$subdir" -o "$subdir" = - ]; then
+        relative="$blob"
+    else
+        relative="$subdir/$blob"
+    fi
+    file="$repo/$relative"
+}
+
+make_blob() {
+    local relative file tag="$1" repo="$2" subdir="$3"
+    setup_file || error "failed to make blob for '$repo'"
+
+    check mkdir -p "$(dirname "$file")"
+    check printf "%s\n" "$blob" > "$file"
+    check git -C "$repo" add "$relative"
+    run printf "%s\n" "${lines[@]}" |
+    run git -C "$repo" interpret-trailers "${trailers[@]}" --trailer "$tag" |
+    execdir mkcommit "$repo" -a -F - || exit 1
+}
+
+main "$@"

--- a/test/bin/test/mkblob-svn.test
+++ b/test/bin/test/mkblob-svn.test
@@ -1,0 +1,333 @@
+RUN: mkblob-svn -h       | grep usage: | check-diff %s USAGE %t
+RUN: mkblob-svn --help   | grep usage: | check-diff %s USAGE %t
+RUN: not mkblob-svn 2>&1 | grep usage: | check-diff %s USAGE %t
+USAGE: usage: mkblob-svn [options] rev [msg...]
+
+RUN: not mkblob-svn -s abc 2>&1 | check-diff %s MISSING-REV %t
+MISSING-REV: error: missing revision; see --help
+
+RUN: not mkblob-svn 0 "msg" 2>&1 | check-diff %s INVALID-REV-0 %t
+RUN: not mkblob-svn 0       2>&1 | check-diff %s INVALID-REV-0 %t
+RUN: not mkblob-svn X "msg" 2>&1 | check-diff %s INVALID-REV-X %t
+RUN: not mkblob-svn X       2>&1 | check-diff %s INVALID-REV-X %t
+INVALID-REV-0: error: invalid revision '0'
+INVALID-REV-X: error: invalid revision 'X'
+
+RUN: not mkblob-svn 5 2>&1 | check-diff %s NO-REPOS %t
+NO-REPOS: error: at least one of '-s' and '-m' required
+
+RUN: rm -rf %t
+RUN: not mkblob-svn -s %t     5 2>&1                 \
+RUN:   | sed -e "s,%t,missing-repo," -e 's,-s ,-X ,' \
+RUN:   | check-diff %s MISSING-REPO %t
+RUN: not mkblob-svn -s %t:sub 5 2>&1                 \
+RUN:   | sed -e "s,%t,missing-repo," -e 's,-s ,-X ,' \
+RUN:   | check-diff %s MISSING-REPO-SUB %t
+RUN: not mkblob-svn -m %t     5 2>&1                 \
+RUN:   | sed -e "s,%t,missing-repo," -e 's,-m ,-X ,' \
+RUN:   | check-diff %s MISSING-REPO %t
+RUN: not mkblob-svn -m %t:sub 5 2>&1                 \
+RUN:   | sed -e "s,%t,missing-repo," -e 's,-m ,-X ,' \
+RUN:   | check-diff %s MISSING-REPO-SUB %t
+MISSING-REPO:     error: cannot find repo for '-X missing-repo'
+MISSING-REPO-SUB: error: cannot find repo for '-X missing-repo:sub'
+
+RUN: mkdir %t
+RUN: not mkblob-svn -s %t     5 2>&1             \
+RUN:   | sed -e "s,%t,bad-repo," -e 's,-s ,-X ,' \
+RUN:   | check-diff %s BAD-REPO %t
+RUN: not mkblob-svn -s %t:sub 5 2>&1             \
+RUN:   | sed -e "s,%t,bad-repo," -e 's,-s ,-X ,' \
+RUN:   | check-diff %s BAD-REPO-SUB %t
+RUN: not mkblob-svn -m %t     5 2>&1             \
+RUN:   | sed -e "s,%t,bad-repo," -e 's,-m ,-X ,' \
+RUN:   | check-diff %s BAD-REPO %t
+RUN: not mkblob-svn -m %t:sub 5 2>&1             \
+RUN:   | sed -e "s,%t,bad-repo," -e 's,-m ,-X ,' \
+RUN:   | check-diff %s BAD-REPO-SUB %t
+BAD-REPO:     error: invalid repo for '-X bad-repo'
+BAD-REPO-SUB: error: invalid repo for '-X bad-repo:sub'
+
+RUN: mkrepo %t-s
+RUN: mkrepo %t-m
+RUN: not mkblob-svn -s %t-s             5 2>&1 \
+RUN:   | sed -e "s,%t-s,repo," -e 's,-s ,-X ,' \
+RUN:   | check-diff %s NO-IMPLIED-DIR %t
+RUN: not mkblob-svn -s %t-s -m %t-m:sub 5 2>&1 \
+RUN:   | sed -e "s,%t-s,repo," -e 's,-s ,-X ,' \
+RUN:   | check-diff %s NO-IMPLIED-DIR %t
+RUN: not mkblob-svn -m %t-m             5 2>&1 \
+RUN:   | sed -e "s,%t-m,repo," -e 's,-m ,-X ,' \
+RUN:   | check-diff %s NO-IMPLIED-DIR %t
+RUN: not mkblob-svn -m %t-m -s %t-s:sub 5 2>&1 \
+RUN:   | sed -e "s,%t-m,repo," -e 's,-m ,-X ,' \
+RUN:   | check-diff %s NO-IMPLIED-DIR %t
+NO-IMPLIED-DIR: error: no implied dir for '-X repo'
+
+RUN: env at=1550000001 mkblob-svn -d subdir -m %t-m   -s %t-s      1
+RUN: env at=1550000002 mkblob-svn -d subdir -m %t-m   -s %t-s -b X 2
+RUN: env at=1550000003 mkblob-svn -d subdir           -s %t-s      3
+RUN: env at=1550000004 mkblob-svn -d subdir -m %t-m                4
+RUN: env at=1550000005 mkblob-svn -d root   -m %t-m:- -s %t-s      5
+RUN: env at=1550000006 mkblob-svn -d -      -m %t-m   -s %t-s:root 6
+RUN: env at=1550000007 mkblob-svn -d subdir -m %t-m:- -s %t-s:root 7
+RUN: env at=1550000008 mkblob-svn           -m %t-m:- -s %t-s:root 8
+RUN: env at=1550000009 mkblob-svn -d subdir -m %t-m -s %t-s 9 subject
+RUN: env at=1550000010 mkblob-svn -d subdir -m %t-m -s %t-s 10 a b c
+RUN: env at=1550000011 mkblob-svn -d subdir -m %t-m -s %t-s 11 -t x:y -t w=z
+RUN: env at=1550000012 mkblob-svn -d subdir -m %t-m -s %t-s 12 -t x:y -t w=z \
+RUN:                                                           a b c
+
+# Check that we error out on duplicates.
+RUN: not mkblob-svn -d subdir -s %t-s 1 2>&1 | sed -e "s,'-s.*','spelling'," \
+RUN:   | check-diff %s DUPLICATE %t
+RUN: not mkblob-svn -d subdir -m %t-m 1 2>&1 | sed -e "s,'-m.*','spelling'," \
+RUN:   | check-diff %s DUPLICATE %t
+DUPLICATE: error: blob '1' already exists for 'spelling'
+
+# Check blob contents.
+RUN: cat %t-s/1 | check-diff %s BLOB-1 %t
+RUN: cat %t-s/X | check-diff %s BLOB-X %t
+RUN: cat %t-s/3 | check-diff %s BLOB-3 %t
+RUN: cat %t-s/5 | check-diff %s BLOB-5 %t
+RUN: cat %t-m/subdir/1 | check-diff %s BLOB-1 %t
+RUN: cat %t-m/subdir/X | check-diff %s BLOB-X %t
+RUN: cat %t-m/subdir/4 | check-diff %s BLOB-4 %t
+RUN: cat %t-m/5        | check-diff %s BLOB-5 %t
+BLOB-1: 1
+BLOB-X: X
+BLOB-3: 3
+BLOB-4: 4
+BLOB-5: 5
+
+# Confirm mkcommit is used under the hood.
+RUN: git -C %t-s log --date=raw -1                                \
+RUN:      --format=format:%%an%%n%%cn%%n%%ae%%n%%ce%%n%%ad%%n%%cd \
+RUN:   | check-diff %s METADATA %t
+RUN: git -C %t-m log --date=raw -1                                \
+RUN:      --format=format:%%an%%n%%cn%%n%%ae%%n%%ce%%n%%ad%%n%%cd \
+RUN:   | check-diff %s METADATA %t
+METADATA: mkblob.sh
+METADATA: mkblob.sh
+METADATA: mkblob@apple.llvm
+METADATA: mkblob@apple.llvm
+METADATA: 1550000012 +0000
+METADATA: 1550000012 +0000
+
+# Check that the git-svn-id tags have the right form (other checks will shorten
+# them).
+RUN: git -C %t-s log --reverse --format=format:%B -1 | grep git-svn-id: \
+RUN:   | check-diff %s GIT-SVN-ID %t
+GIT-SVN-ID: git-svn-id: https://llvm.org/svn/llvm-project/subdir/trunk@12 91177308-0d34-0410-b5e6-96231b3b80d8
+
+# Check the logs and paths.
+RUN: git -C %t-s log --reverse --format=format:--%n%B --name-status \
+RUN:   | sed -e 's,https://llvm.org/svn/llvm-project/,,'            \
+RUN:         -e 's,/trunk\(@[0-9]*\) .*,\1,'                        \
+RUN:   | check-diff %s LOG-SPLIT %t
+LOG-SPLIT: --
+LOG-SPLIT: mkblob-svn: r1
+LOG-SPLIT:
+LOG-SPLIT: added the blob '1'
+LOG-SPLIT:
+LOG-SPLIT: git-svn-id: subdir@1
+LOG-SPLIT:
+LOG-SPLIT: A 1
+LOG-SPLIT:
+LOG-SPLIT: --
+LOG-SPLIT: mkblob-svn: r2
+LOG-SPLIT:
+LOG-SPLIT: added the blob 'X'
+LOG-SPLIT:
+LOG-SPLIT: git-svn-id: subdir@2
+LOG-SPLIT:
+LOG-SPLIT: A X
+LOG-SPLIT:
+LOG-SPLIT: --
+LOG-SPLIT: mkblob-svn: r3
+LOG-SPLIT:
+LOG-SPLIT: added the blob '3'
+LOG-SPLIT:
+LOG-SPLIT: git-svn-id: subdir@3
+LOG-SPLIT:
+LOG-SPLIT: A 3
+LOG-SPLIT:
+LOG-SPLIT: --
+LOG-SPLIT: mkblob-svn: r5
+LOG-SPLIT:
+LOG-SPLIT: added the blob '5'
+LOG-SPLIT:
+LOG-SPLIT: git-svn-id: root@5
+LOG-SPLIT:
+LOG-SPLIT: A 5
+LOG-SPLIT:
+LOG-SPLIT: --
+LOG-SPLIT: mkblob-svn: r6
+LOG-SPLIT:
+LOG-SPLIT: added the blob '6'
+LOG-SPLIT:
+LOG-SPLIT: git-svn-id: root@6
+LOG-SPLIT:
+LOG-SPLIT: A 6
+LOG-SPLIT:
+LOG-SPLIT: --
+LOG-SPLIT: mkblob-svn: r7
+LOG-SPLIT:
+LOG-SPLIT: added the blob '7'
+LOG-SPLIT:
+LOG-SPLIT: git-svn-id: root@7
+LOG-SPLIT:
+LOG-SPLIT: A 7
+LOG-SPLIT:
+LOG-SPLIT: --
+LOG-SPLIT: mkblob-svn: r8
+LOG-SPLIT:
+LOG-SPLIT: added the blob '8'
+LOG-SPLIT:
+LOG-SPLIT: git-svn-id: root@8
+LOG-SPLIT:
+LOG-SPLIT: A 8
+LOG-SPLIT:
+LOG-SPLIT: --
+LOG-SPLIT: subject
+LOG-SPLIT:
+LOG-SPLIT: git-svn-id: subdir@9
+LOG-SPLIT:
+LOG-SPLIT: A 9
+LOG-SPLIT:
+LOG-SPLIT: --
+LOG-SPLIT: a
+LOG-SPLIT:
+LOG-SPLIT: b
+LOG-SPLIT: c
+LOG-SPLIT:
+LOG-SPLIT: git-svn-id: subdir@10
+LOG-SPLIT:
+LOG-SPLIT: A 10
+LOG-SPLIT:
+LOG-SPLIT: --
+LOG-SPLIT: mkblob-svn: r11
+LOG-SPLIT:
+LOG-SPLIT: added the blob '11'
+LOG-SPLIT:
+LOG-SPLIT: x: y
+LOG-SPLIT: w: z
+LOG-SPLIT: git-svn-id: subdir@11
+LOG-SPLIT:
+LOG-SPLIT: A 11
+LOG-SPLIT:
+LOG-SPLIT: --
+LOG-SPLIT: a
+LOG-SPLIT:
+LOG-SPLIT: b
+LOG-SPLIT: c
+LOG-SPLIT:
+LOG-SPLIT: x: y
+LOG-SPLIT: w: z
+LOG-SPLIT: git-svn-id: subdir@12
+LOG-SPLIT:
+LOG-SPLIT: A 12
+RUN: git -C %t-m log --reverse --format=format:--%n%B --name-status \
+RUN:   | check-diff %s LOG-MONO %t
+LOG-MONO: --
+LOG-MONO: mkblob-svn: r1
+LOG-MONO:
+LOG-MONO: added the blob '1'
+LOG-MONO:
+LOG-MONO: llvm-svn: 1
+LOG-MONO:
+LOG-MONO: A subdir/1
+LOG-MONO:
+LOG-MONO: --
+LOG-MONO: mkblob-svn: r2
+LOG-MONO:
+LOG-MONO: added the blob 'X'
+LOG-MONO:
+LOG-MONO: llvm-svn: 2
+LOG-MONO:
+LOG-MONO: A subdir/X
+LOG-MONO:
+LOG-MONO: --
+LOG-MONO: mkblob-svn: r4
+LOG-MONO:
+LOG-MONO: added the blob '4'
+LOG-MONO:
+LOG-MONO: llvm-svn: 4
+LOG-MONO:
+LOG-MONO: A subdir/4
+LOG-MONO:
+LOG-MONO: --
+LOG-MONO: mkblob-svn: r5
+LOG-MONO:
+LOG-MONO: added the blob '5'
+LOG-MONO:
+LOG-MONO: llvm-svn: 5
+LOG-MONO:
+LOG-MONO: A 5
+LOG-MONO:
+LOG-MONO: --
+LOG-MONO: mkblob-svn: r6
+LOG-MONO:
+LOG-MONO: added the blob '6'
+LOG-MONO:
+LOG-MONO: llvm-svn: 6
+LOG-MONO:
+LOG-MONO: A 6
+LOG-MONO:
+LOG-MONO: --
+LOG-MONO: mkblob-svn: r7
+LOG-MONO:
+LOG-MONO: added the blob '7'
+LOG-MONO:
+LOG-MONO: llvm-svn: 7
+LOG-MONO:
+LOG-MONO: A 7
+LOG-MONO:
+LOG-MONO: --
+LOG-MONO: mkblob-svn: r8
+LOG-MONO:
+LOG-MONO: added the blob '8'
+LOG-MONO:
+LOG-MONO: llvm-svn: 8
+LOG-MONO:
+LOG-MONO: A 8
+LOG-MONO:
+LOG-MONO: --
+LOG-MONO: subject
+LOG-MONO:
+LOG-MONO: llvm-svn: 9
+LOG-MONO:
+LOG-MONO: A subdir/9
+LOG-MONO:
+LOG-MONO: --
+LOG-MONO: a
+LOG-MONO:
+LOG-MONO: b
+LOG-MONO: c
+LOG-MONO:
+LOG-MONO: llvm-svn: 10
+LOG-MONO:
+LOG-MONO: A subdir/10
+LOG-MONO:
+LOG-MONO: --
+LOG-MONO: mkblob-svn: r11
+LOG-MONO:
+LOG-MONO: added the blob '11'
+LOG-MONO:
+LOG-MONO: x: y
+LOG-MONO: w: z
+LOG-MONO: llvm-svn: 11
+LOG-MONO:
+LOG-MONO: A subdir/11
+LOG-MONO:
+LOG-MONO: --
+LOG-MONO: a
+LOG-MONO:
+LOG-MONO: b
+LOG-MONO: c
+LOG-MONO:
+LOG-MONO: x: y
+LOG-MONO: w: z
+LOG-MONO: llvm-svn: 12
+LOG-MONO:
+LOG-MONO: A subdir/12

--- a/test/split2mono/svn-fast-cherry-pick-and-merge-reverse.test
+++ b/test/split2mono/svn-fast-cherry-pick-and-merge-reverse.test
@@ -1,0 +1,86 @@
+RUN: rm -rf %t.svn2git %t.split2mono
+RUN: mkdir %t.split2mono
+RUN: %svn2git create %t.svn2git
+RUN: %split2mono create %t.split2mono db
+
+# Create r1 and r3.  Note that setting the author timestamp with 'at' also
+# changes the default 'ct'.
+RUN: mkrepo %t-s
+RUN: mkrepo %t-m
+RUN: env at=1550000001 mkblob-svn -s %t-s -m %t-m -d sub 1
+RUN: git -C %t-m rev-list -1 master | xargs %svn2git insert %t.svn2git 1
+RUN: git -C %t-s branch r1
+RUN: env at=1550000003 mkblob-svn -s %t-s -m %t-m -d sub 3
+RUN: git -C %t-m rev-list -1 master | xargs %svn2git insert %t.svn2git 3
+RUN: git -C %t-s branch r3
+
+# Create a branch from r1, add a commit identical to r3 on top of a downstream
+# commit, add a commit to the downstream branch, and merge the downstream
+# branch in.  This mimics having an extra-fast cherry-pick in a pull request
+# that merges in a new commit from the branch before getting closed.
+RUN: git -C %t-s checkout -b fcp-and-merge r1
+RUN: env at=1550000002 mkblob %t-s 2
+RUN: git -C %t-s checkout -b fast-cherry-pick
+RUN: env at=1550000003 mkblob-svn -s %t-s -d sub 3
+RUN: git -C %t-s checkout fcp-and-merge
+RUN: env at=1550000004 mkblob %t-s 4
+RUN: git -C %t-s checkout fast-cherry-pick
+RUN: env at=1550000005 mkmerge %t-s 5 fcp-and-merge
+RUN: git -C %t-s checkout fcp-and-merge
+RUN: git -C %t-s merge --ff-only fast-cherry-pick
+
+# Give %t-m access to %t-s.
+RUN: git -C %t-m remote add s %t-s
+RUN: git -C %t-m remote update
+
+RUN: git -C %t-m apple-llvm mt list-commits sub s/fcp-and-merge \
+RUN:   | %split2mono -C %t-m interleave-commits                 \
+RUN:     %t.split2mono %t.svn2git                               \
+RUN:     0000000000000000000000000000000000000000               \
+RUN:     0000000000000000000000000000000000000000:sub >%t.out
+RUN: cat %t.out | awk '{print $1}' \
+RUN:   | xargs git -C %t-m update-ref fcp-and-merge
+RUN: number-commits -p SREV %t-s master                     >%t.map
+RUN: number-commits -p SFAM %t-s fcp-and-merge --not master >>%t.map
+RUN: number-commits -p MREV %t-m master                     >>%t.map
+RUN: number-commits -p MFAM %t-m fcp-and-merge --not master >>%t.map
+RUN: git -C %t-m log fcp-and-merge                         \
+RUN:       --format="--%%n%%H %%P %%s%%n%%(trailers:only)" \
+RUN:       --stat --name-status --date-order               \
+RUN:   | apply-commit-numbers %t.map | grep -e . | check-diff %s LOG %t
+LOG: --
+LOG: MFAM-4 MFAM-2 MFAM-3 mkmerge: 5
+LOG: apple-llvm-split-commit: SFAM-4
+LOG: apple-llvm-split-dir: sub/
+LOG: --
+LOG: MFAM-3 MFAM-1 mkblob: 4
+LOG: apple-llvm-split-commit: SFAM-3
+LOG: apple-llvm-split-dir: sub/
+LOG: A sub/4
+LOG: --
+LOG: MFAM-2 MFAM-1 mkblob-svn: r3
+LOG: git-svn-id: https://llvm.org/svn/llvm-project/sub/trunk@3 91177308-0d34-0410-b5e6-96231b3b80d8
+LOG: apple-llvm-split-commit: SFAM-2
+LOG: apple-llvm-split-dir: sub/
+LOG: A sub/3
+LOG: --
+LOG: MFAM-1 MREV-1 mkblob: 2
+LOG: apple-llvm-split-commit: SFAM-1
+LOG: apple-llvm-split-dir: sub/
+LOG: A sub/2
+LOG: --
+LOG: MREV-1 mkblob-svn: r1
+LOG: llvm-svn: 1
+LOG: A sub/1
+RUN: cat %t.out | apply-commit-numbers %t.map | check-diff %s OUT %t
+OUT: MFAM-4 SFAM-4:sub
+RUN: %split2mono dump %t.split2mono | apply-commit-numbers %t.map \
+RUN:   | grep -e sha1= -e split= | check-diff %s DUMP %t
+DUMP: 00000000: split=SFAM-1 mono=MFAM-1
+DUMP: 00000001: split=SFAM-2 mono=MFAM-2
+DUMP: 00000002: split=SFAM-3 mono=MFAM-3
+DUMP: 00000003: split=SFAM-4 mono=MFAM-4
+DUMP: 00000000: sha1=MFAM-1 rev=-1
+DUMP: 00000001: sha1=MFAM-2 rev=-1
+DUMP: 00000002: sha1=MFAM-3 rev=-1
+DUMP: 00000003: sha1=MFAM-4 rev=-1

--- a/test/split2mono/svn-fast-cherry-pick-and-merge.test
+++ b/test/split2mono/svn-fast-cherry-pick-and-merge.test
@@ -1,0 +1,74 @@
+RUN: rm -rf %t.svn2git %t.split2mono
+RUN: mkdir %t.split2mono
+RUN: %svn2git create %t.svn2git
+RUN: %split2mono create %t.split2mono db
+
+# Create r1 and r3.  Note that setting the author timestamp with 'at' also
+# changes the default 'ct'.
+RUN: mkrepo %t-s
+RUN: mkrepo %t-m
+RUN: env at=1550000001 mkblob-svn -s %t-s -m %t-m -d sub 1
+RUN: git -C %t-m rev-list -1 master | xargs %svn2git insert %t.svn2git 1
+RUN: git -C %t-s branch r1
+RUN: env at=1550000003 mkblob-svn -s %t-s -m %t-m -d sub 3
+RUN: git -C %t-m rev-list -1 master | xargs %svn2git insert %t.svn2git 3
+RUN: git -C %t-s branch r3
+
+# Create a branch from r1, add a commit identical to r3 on top of a downstream
+# commit, and merge it back into the downstream branch.  This mimics having an
+# extra-fast cherry-pick in a pull request that gets merged in.
+RUN: git -C %t-s checkout -b fcp-and-merge r1
+RUN: env at=1550000002 mkblob %t-s 2
+RUN: git -C %t-s checkout -b fast-cherry-pick
+RUN: env at=1550000003 mkblob-svn -s %t-s -d sub 3
+RUN: git -C %t-s checkout fcp-and-merge
+RUN: env at=1550000004 mkmerge %t-s 4 fast-cherry-pick
+
+# Give %t-m access to %t-s.
+RUN: git -C %t-m remote add s %t-s
+RUN: git -C %t-m remote update
+
+RUN: git -C %t-m apple-llvm mt list-commits sub s/fcp-and-merge \
+RUN:   | %split2mono -C %t-m interleave-commits                 \
+RUN:     %t.split2mono %t.svn2git                               \
+RUN:     0000000000000000000000000000000000000000               \
+RUN:     0000000000000000000000000000000000000000:sub >%t.out
+RUN: cat %t.out | awk '{print $1}' \
+RUN:   | xargs git -C %t-m update-ref fcp-and-merge
+RUN: number-commits -p SREV %t-s master                     >%t.map
+RUN: number-commits -p SFAM %t-s fcp-and-merge --not master >>%t.map
+RUN: number-commits -p MREV %t-m master                     >>%t.map
+RUN: number-commits -p MFAM %t-m fcp-and-merge --not master >>%t.map
+RUN: git -C %t-m log fcp-and-merge                         \
+RUN:       --format="--%%n%%H %%P %%s%%n%%(trailers:only)" \
+RUN:       --stat --name-status                            \
+RUN:   | apply-commit-numbers %t.map | grep -e . | check-diff %s LOG %t
+LOG: --
+LOG: MFAM-3 MFAM-1 MFAM-2 mkmerge: 4
+LOG: apple-llvm-split-commit: SFAM-3
+LOG: apple-llvm-split-dir: sub/
+LOG: --
+LOG: MFAM-2 MFAM-1 mkblob-svn: r3
+LOG: git-svn-id: https://llvm.org/svn/llvm-project/sub/trunk@3 91177308-0d34-0410-b5e6-96231b3b80d8
+LOG: apple-llvm-split-commit: SFAM-2
+LOG: apple-llvm-split-dir: sub/
+LOG: A sub/3
+LOG: --
+LOG: MFAM-1 MREV-1 mkblob: 2
+LOG: apple-llvm-split-commit: SFAM-1
+LOG: apple-llvm-split-dir: sub/
+LOG: A sub/2
+LOG: --
+LOG: MREV-1 mkblob-svn: r1
+LOG: llvm-svn: 1
+LOG: A sub/1
+RUN: cat %t.out | apply-commit-numbers %t.map | check-diff %s OUT %t
+OUT: MFAM-3 SFAM-3:sub
+RUN: %split2mono dump %t.split2mono | apply-commit-numbers %t.map \
+RUN:   | grep -e sha1= -e split= | check-diff %s DUMP %t
+DUMP: 00000000: split=SFAM-1 mono=MFAM-1
+DUMP: 00000001: split=SFAM-2 mono=MFAM-2
+DUMP: 00000002: split=SFAM-3 mono=MFAM-3
+DUMP: 00000000: sha1=MFAM-1 rev=-1
+DUMP: 00000001: sha1=MFAM-2 rev=-1
+DUMP: 00000002: sha1=MFAM-3 rev=-1

--- a/test/split2mono/svn-fast-cherry-pick.test
+++ b/test/split2mono/svn-fast-cherry-pick.test
@@ -1,0 +1,73 @@
+RUN: rm -rf %t.svn2git %t.split2mono
+RUN: mkdir %t.split2mono
+RUN: %svn2git create %t.svn2git
+RUN: %split2mono create %t.split2mono db
+
+# Create r1 and r3.  Note that setting the author timestamp with 'at' also
+# changes the default 'ct'.
+RUN: mkrepo %t-s
+RUN: mkrepo %t-m
+RUN: env at=1550000001 mkblob-svn -s %t-s -m %t-m -d sub 1
+RUN: git -C %t-m rev-list -1 master | xargs %svn2git insert %t.svn2git 1
+RUN: git -C %t-s branch r1
+RUN: env at=1550000003 mkblob-svn -s %t-s -m %t-m -d sub 3
+RUN: git -C %t-m rev-list -1 master | xargs %svn2git insert %t.svn2git 3
+RUN: git -C %t-s branch r3
+
+# Create a branch from r1, add a commit identical to r3 on top of a downstream
+# commit, and add another downstream commit.  This mimics having an extra-fast
+# cherry-pick as a parent.
+RUN: git -C %t-s checkout -b fast-cherry-pick r1
+RUN: env at=1550000002 mkblob %t-s 2
+RUN: env at=1550000003 mkblob-svn -s %t-s -d sub 3
+RUN: env at=1550000004 mkblob %t-s 4
+
+# Give %t-m access to %t-s.
+RUN: git -C %t-m remote add s %t-s
+RUN: git -C %t-m remote update
+
+RUN: git -C %t-m apple-llvm mt list-commits sub s/fast-cherry-pick \
+RUN:   | %split2mono -C %t-m interleave-commits                    \
+RUN:     %t.split2mono %t.svn2git                                  \
+RUN:     0000000000000000000000000000000000000000                  \
+RUN:     0000000000000000000000000000000000000000:sub >%t.out
+RUN: cat %t.out | awk '{print $1}' \
+RUN:   | xargs git -C %t-m update-ref fast-cherry-pick
+RUN: number-commits -p SREV %t-s master                         >%t.map
+RUN: number-commits -p SFCP %t-s fast-cherry-pick --not master >>%t.map
+RUN: number-commits -p MREV %t-m master                        >>%t.map
+RUN: number-commits -p MFCP %t-m fast-cherry-pick --not master >>%t.map
+RUN: git -C %t-m log fast-cherry-pick                   \
+RUN:       --format="--%%n%%H %%s%%n%%(trailers:only)"  \
+RUN:       --stat --name-status                         \
+RUN:   | apply-commit-numbers %t.map | grep -e . | check-diff %s LOG %t
+LOG: --
+LOG: MFCP-3 mkblob: 4
+LOG: apple-llvm-split-commit: SFCP-3
+LOG: apple-llvm-split-dir: sub/
+LOG: A sub/4
+LOG: --
+LOG: MFCP-2 mkblob-svn: r3
+LOG: git-svn-id: https://llvm.org/svn/llvm-project/sub/trunk@3 91177308-0d34-0410-b5e6-96231b3b80d8
+LOG: apple-llvm-split-commit: SFCP-2
+LOG: apple-llvm-split-dir: sub/
+LOG: A sub/3
+LOG: --
+LOG: MFCP-1 mkblob: 2
+LOG: apple-llvm-split-commit: SFCP-1
+LOG: apple-llvm-split-dir: sub/
+LOG: A sub/2
+LOG: --
+LOG: MREV-1 mkblob-svn: r1
+LOG: llvm-svn: 1
+LOG: A sub/1
+RUN: cat %t.out | apply-commit-numbers %t.map | check-diff %s OUT %t
+OUT: MFCP-3 SFCP-3:sub
+RUN: %split2mono dump %t.split2mono | apply-commit-numbers %t.map \
+RUN:   | grep -e sha1= -e split= | check-diff %s DUMP %t
+DUMP: 00000000: split=SFCP-1 mono=MFCP-1
+DUMP: 00000001: split=SFCP-2 mono=MFCP-2
+DUMP: 00000002: split=SFCP-3 mono=MFCP-3
+DUMP: 00000000: sha1=MFCP-1 rev=-1
+DUMP: 00000001: sha1=MFCP-2 rev=-1
+DUMP: 00000002: sha1=MFCP-3 rev=-1

--- a/test/split2mono/svn-merge-mismatched-date.test
+++ b/test/split2mono/svn-merge-mismatched-date.test
@@ -1,0 +1,71 @@
+RUN: rm -rf %t.svn2git %t.split2mono
+RUN: mkdir %t.split2mono
+RUN: %svn2git create %t.svn2git
+RUN: %split2mono create %t.split2mono db
+
+# Create r1 and r3.  Note that setting the author timestamp with 'at' also
+# changes the default 'ct'.
+RUN: mkrepo %t-s
+RUN: mkrepo %t-m
+RUN: env at=1550000001 mkblob-svn -s %t-s -m %t-m -d sub 1
+RUN: git -C %t-m rev-list -1 master | xargs %svn2git insert %t.svn2git 1
+RUN: git -C %t-s branch r1
+
+# Use a mismatched date for r3 by setting ct instead of at.
+RUN: env ct=1550000003 mkblob-svn -s %t-s -m %t-m -d sub 3
+RUN: git -C %t-m rev-list -1 master | xargs %svn2git insert %t.svn2git 3
+RUN: git -C %t-s branch r3
+
+# Create a branch from r1, add a commit identical to r3 on top of a downstream
+# commit, and add another downstream commit.  This mimics having an extra-fast
+# cherry-pick as a parent.
+RUN: git -C %t-s checkout -b downstream r1
+RUN: env at=1550000002 mkblob %t-s 2
+RUN: env at=1550000004 mkmerge %t-s 4 r3
+
+# Give %t-m access to %t-s.
+RUN: git -C %t-m remote add s %t-s
+RUN: git -C %t-m remote update
+
+RUN: git -C %t-m apple-llvm mt list-commits sub s/downstream \
+RUN:   | %split2mono -C %t-m interleave-commits              \
+RUN:     %t.split2mono %t.svn2git                            \
+RUN:     0000000000000000000000000000000000000000            \
+RUN:     0000000000000000000000000000000000000000:sub >%t.out
+RUN: cat %t.out | awk '{print $1}' \
+RUN:   | xargs git -C %t-m update-ref downstream
+RUN: number-commits -p SUP   %t-s master                   >%t.map
+RUN: number-commits -p SDOWN %t-s downstream --not master >>%t.map
+RUN: number-commits -p MUP   %t-m master                  >>%t.map
+RUN: number-commits -p MDOWN %t-m downstream --not master >>%t.map
+RUN: git -C %t-m log downstream                            \
+RUN:       --format="--%%n%%H %%P %%s%%n%%(trailers:only)" \
+RUN:       --stat --name-status --date-order               \
+RUN:   | apply-commit-numbers %t.map | grep -e . | check-diff %s LOG %t
+LOG: --
+LOG: MDOWN-3 MDOWN-1 MDOWN-2 mkmerge: 4
+LOG: apple-llvm-split-commit: SDOWN-2
+LOG: apple-llvm-split-dir: sub/
+LOG: --
+LOG: MDOWN-2 MUP-1 mkblob-svn: r3
+LOG: git-svn-id: https://llvm.org/svn/llvm-project/sub/trunk@3 91177308-0d34-0410-b5e6-96231b3b80d8
+LOG: apple-llvm-split-commit: SUP-2
+LOG: apple-llvm-split-dir: sub/
+LOG: A sub/3
+LOG: --
+LOG: MDOWN-1 MUP-1 mkblob: 2
+LOG: apple-llvm-split-commit: SDOWN-1
+LOG: apple-llvm-split-dir: sub/
+LOG: A sub/2
+LOG: --
+LOG: MUP-1 mkblob-svn: r1
+LOG: llvm-svn: 1
+LOG: A sub/1
+RUN: %split2mono dump %t.split2mono | apply-commit-numbers %t.map \
+RUN:   | grep -e sha1= -e split= | check-diff %s DUMP %t
+DUMP: 00000000: split=SDOWN-1 mono=MDOWN-1
+DUMP: 00000001: split=SUP-2   mono=MDOWN-2
+DUMP: 00000002: split=SDOWN-2 mono=MDOWN-3
+DUMP: 00000000: sha1=MDOWN-1 rev=-1
+DUMP: 00000001: sha1=MDOWN-2 rev=-1
+DUMP: 00000002: sha1=MDOWN-3 rev=-1

--- a/test/split2mono/svn-merge-mismatched-email.test
+++ b/test/split2mono/svn-merge-mismatched-email.test
@@ -1,0 +1,71 @@
+RUN: rm -rf %t.svn2git %t.split2mono
+RUN: mkdir %t.split2mono
+RUN: %svn2git create %t.svn2git
+RUN: %split2mono create %t.split2mono db
+
+# Create r1 and r3.  Note that setting the author timestamp with 'at' also
+# changes the default 'ct'.
+RUN: mkrepo %t-s
+RUN: mkrepo %t-m
+RUN: env at=1550000001 mkblob-svn -s %t-s -m %t-m -d sub 1
+RUN: git -C %t-m rev-list -1 master | xargs %svn2git insert %t.svn2git 1
+RUN: git -C %t-s branch r1
+
+# Use a mismatched email but setting ce but not ae.
+RUN: env at=1550000003 ce=wrong@email mkblob-svn -s %t-s -m %t-m -d sub 3
+RUN: git -C %t-m rev-list -1 master | xargs %svn2git insert %t.svn2git 3
+RUN: git -C %t-s branch r3
+
+# Create a branch from r1, add a commit identical to r3 on top of a downstream
+# commit, and add another downstream commit.  This mimics having an extra-fast
+# cherry-pick as a parent.
+RUN: git -C %t-s checkout -b downstream r1
+RUN: env at=1550000002 mkblob %t-s 2
+RUN: env at=1550000004 mkmerge %t-s 4 r3
+
+# Give %t-m access to %t-s.
+RUN: git -C %t-m remote add s %t-s
+RUN: git -C %t-m remote update
+
+RUN: git -C %t-m apple-llvm mt list-commits sub s/downstream \
+RUN:   | %split2mono -C %t-m interleave-commits              \
+RUN:     %t.split2mono %t.svn2git                            \
+RUN:     0000000000000000000000000000000000000000            \
+RUN:     0000000000000000000000000000000000000000:sub >%t.out
+RUN: cat %t.out | awk '{print $1}' \
+RUN:   | xargs git -C %t-m update-ref downstream
+RUN: number-commits -p SUP   %t-s master                   >%t.map
+RUN: number-commits -p SDOWN %t-s downstream --not master >>%t.map
+RUN: number-commits -p MUP   %t-m master                  >>%t.map
+RUN: number-commits -p MDOWN %t-m downstream --not master >>%t.map
+RUN: git -C %t-m log downstream                            \
+RUN:       --format="--%%n%%H %%P %%s%%n%%(trailers:only)" \
+RUN:       --stat --name-status --date-order               \
+RUN:   | apply-commit-numbers %t.map | grep -e . | check-diff %s LOG %t
+LOG: --
+LOG: MDOWN-3 MDOWN-1 MDOWN-2 mkmerge: 4
+LOG: apple-llvm-split-commit: SDOWN-2
+LOG: apple-llvm-split-dir: sub/
+LOG: --
+LOG: MDOWN-2 MUP-1 mkblob-svn: r3
+LOG: git-svn-id: https://llvm.org/svn/llvm-project/sub/trunk@3 91177308-0d34-0410-b5e6-96231b3b80d8
+LOG: apple-llvm-split-commit: SUP-2
+LOG: apple-llvm-split-dir: sub/
+LOG: A sub/3
+LOG: --
+LOG: MDOWN-1 MUP-1 mkblob: 2
+LOG: apple-llvm-split-commit: SDOWN-1
+LOG: apple-llvm-split-dir: sub/
+LOG: A sub/2
+LOG: --
+LOG: MUP-1 mkblob-svn: r1
+LOG: llvm-svn: 1
+LOG: A sub/1
+RUN: %split2mono dump %t.split2mono | apply-commit-numbers %t.map \
+RUN:   | grep -e sha1= -e split= | check-diff %s DUMP %t
+DUMP: 00000000: split=SDOWN-1 mono=MDOWN-1
+DUMP: 00000001: split=SUP-2   mono=MDOWN-2
+DUMP: 00000002: split=SDOWN-2 mono=MDOWN-3
+DUMP: 00000000: sha1=MDOWN-1 rev=-1
+DUMP: 00000001: sha1=MDOWN-2 rev=-1
+DUMP: 00000002: sha1=MDOWN-3 rev=-1

--- a/test/split2mono/svn-merge-mismatched-name.test
+++ b/test/split2mono/svn-merge-mismatched-name.test
@@ -1,0 +1,71 @@
+RUN: rm -rf %t.svn2git %t.split2mono
+RUN: mkdir %t.split2mono
+RUN: %svn2git create %t.svn2git
+RUN: %split2mono create %t.split2mono db
+
+# Create r1 and r3.  Note that setting the author timestamp with 'at' also
+# changes the default 'ct'.
+RUN: mkrepo %t-s
+RUN: mkrepo %t-m
+RUN: env at=1550000001 mkblob-svn -s %t-s -m %t-m -d sub 1
+RUN: git -C %t-m rev-list -1 master | xargs %svn2git insert %t.svn2git 1
+RUN: git -C %t-s branch r1
+
+# Use a mismatched name by setting cn but not an.
+RUN: env at=1550000003 cn="wrong name" mkblob-svn -s %t-s -m %t-m -d sub 3
+RUN: git -C %t-m rev-list -1 master | xargs %svn2git insert %t.svn2git 3
+RUN: git -C %t-s branch r3
+
+# Create a branch from r1, add a commit identical to r3 on top of a downstream
+# commit, and add another downstream commit.  This mimics having an extra-fast
+# cherry-pick as a parent.
+RUN: git -C %t-s checkout -b downstream r1
+RUN: env at=1550000002 mkblob %t-s 2
+RUN: env at=1550000004 mkmerge %t-s 4 r3
+
+# Give %t-m access to %t-s.
+RUN: git -C %t-m remote add s %t-s
+RUN: git -C %t-m remote update
+
+RUN: git -C %t-m apple-llvm mt list-commits sub s/downstream \
+RUN:   | %split2mono -C %t-m interleave-commits              \
+RUN:     %t.split2mono %t.svn2git                            \
+RUN:     0000000000000000000000000000000000000000            \
+RUN:     0000000000000000000000000000000000000000:sub >%t.out
+RUN: cat %t.out | awk '{print $1}' \
+RUN:   | xargs git -C %t-m update-ref downstream
+RUN: number-commits -p SUP   %t-s master                   >%t.map
+RUN: number-commits -p SDOWN %t-s downstream --not master >>%t.map
+RUN: number-commits -p MUP   %t-m master                  >>%t.map
+RUN: number-commits -p MDOWN %t-m downstream --not master >>%t.map
+RUN: git -C %t-m log downstream                            \
+RUN:       --format="--%%n%%H %%P %%s%%n%%(trailers:only)" \
+RUN:       --stat --name-status --date-order               \
+RUN:   | apply-commit-numbers %t.map | grep -e . | check-diff %s LOG %t
+LOG: --
+LOG: MDOWN-3 MDOWN-1 MDOWN-2 mkmerge: 4
+LOG: apple-llvm-split-commit: SDOWN-2
+LOG: apple-llvm-split-dir: sub/
+LOG: --
+LOG: MDOWN-2 MUP-1 mkblob-svn: r3
+LOG: git-svn-id: https://llvm.org/svn/llvm-project/sub/trunk@3 91177308-0d34-0410-b5e6-96231b3b80d8
+LOG: apple-llvm-split-commit: SUP-2
+LOG: apple-llvm-split-dir: sub/
+LOG: A sub/3
+LOG: --
+LOG: MDOWN-1 MUP-1 mkblob: 2
+LOG: apple-llvm-split-commit: SDOWN-1
+LOG: apple-llvm-split-dir: sub/
+LOG: A sub/2
+LOG: --
+LOG: MUP-1 mkblob-svn: r1
+LOG: llvm-svn: 1
+LOG: A sub/1
+RUN: %split2mono dump %t.split2mono | apply-commit-numbers %t.map \
+RUN:   | grep -e sha1= -e split= | check-diff %s DUMP %t
+DUMP: 00000000: split=SDOWN-1 mono=MDOWN-1
+DUMP: 00000001: split=SUP-2   mono=MDOWN-2
+DUMP: 00000002: split=SDOWN-2 mono=MDOWN-3
+DUMP: 00000000: sha1=MDOWN-1 rev=-1
+DUMP: 00000001: sha1=MDOWN-2 rev=-1
+DUMP: 00000002: sha1=MDOWN-3 rev=-1

--- a/test/split2mono/svn-merge-not-in-monorepo.test
+++ b/test/split2mono/svn-merge-not-in-monorepo.test
@@ -1,0 +1,70 @@
+RUN: rm -rf %t.svn2git %t.split2mono
+RUN: mkdir %t.split2mono
+RUN: %svn2git create %t.svn2git
+RUN: %split2mono create %t.split2mono db
+
+# Create r1 and r3.  Note that setting the author timestamp with 'at' also
+# changes the default 'ct'.
+RUN: mkrepo %t-s
+RUN: mkrepo %t-m
+RUN: env at=1550000001 mkblob-svn -s %t-s -m %t-m -d sub 1
+RUN: git -C %t-m rev-list -1 master | xargs %svn2git insert %t.svn2git 1
+RUN: git -C %t-s branch r1
+# Note: intentionally leaving r3 out of the monorepo here, to mimic commits
+# like r137571 on branches that are not being translated.
+RUN: env at=1550000003 mkblob-svn -s %t-s -d sub 3
+RUN: git -C %t-s branch r3
+
+# Create a branch from r1, add a commit identical to r3 on top of a downstream
+# commit, and add another downstream commit.  This mimics having an extra-fast
+# cherry-pick as a parent.
+RUN: git -C %t-s checkout -b downstream r1
+RUN: env at=1550000002 mkblob %t-s 2
+RUN: env at=1550000004 mkmerge %t-s 4 r3
+
+# Give %t-m access to %t-s.
+RUN: git -C %t-m remote add s %t-s
+RUN: git -C %t-m remote update
+
+RUN: git -C %t-m apple-llvm mt list-commits sub s/downstream \
+RUN:   | %split2mono -C %t-m interleave-commits              \
+RUN:     %t.split2mono %t.svn2git                            \
+RUN:     0000000000000000000000000000000000000000            \
+RUN:     0000000000000000000000000000000000000000:sub >%t.out
+RUN: cat %t.out | awk '{print $1}' \
+RUN:   | xargs git -C %t-m update-ref downstream
+RUN: number-commits -p SUP   %t-s master                   >%t.map
+RUN: number-commits -p SDOWN %t-s downstream --not master >>%t.map
+RUN: number-commits -p MUP   %t-m master                  >>%t.map
+RUN: number-commits -p MDOWN %t-m downstream --not master >>%t.map
+RUN: git -C %t-m log downstream                            \
+RUN:       --format="--%%n%%H %%P %%s%%n%%(trailers:only)" \
+RUN:       --stat --name-status --date-order               \
+RUN:   | apply-commit-numbers %t.map | grep -e . | check-diff %s LOG %t
+LOG: --
+LOG: MDOWN-3 MDOWN-1 MDOWN-2 mkmerge: 4
+LOG: apple-llvm-split-commit: SDOWN-2
+LOG: apple-llvm-split-dir: sub/
+LOG: --
+LOG: MDOWN-2 MUP-1 mkblob-svn: r3
+LOG: git-svn-id: https://llvm.org/svn/llvm-project/sub/trunk@3 91177308-0d34-0410-b5e6-96231b3b80d8
+LOG: apple-llvm-split-commit: SUP-2
+LOG: apple-llvm-split-dir: sub/
+LOG: A sub/3
+LOG: --
+LOG: MDOWN-1 MUP-1 mkblob: 2
+LOG: apple-llvm-split-commit: SDOWN-1
+LOG: apple-llvm-split-dir: sub/
+LOG: A sub/2
+LOG: --
+LOG: MUP-1 mkblob-svn: r1
+LOG: llvm-svn: 1
+LOG: A sub/1
+RUN: %split2mono dump %t.split2mono | apply-commit-numbers %t.map \
+RUN:   | grep -e sha1= -e split= | check-diff %s DUMP %t
+DUMP: 00000000: split=SDOWN-1 mono=MDOWN-1
+DUMP: 00000001: split=SUP-2   mono=MDOWN-2
+DUMP: 00000002: split=SDOWN-2 mono=MDOWN-3
+DUMP: 00000000: sha1=MDOWN-1 rev=-1
+DUMP: 00000001: sha1=MDOWN-2 rev=-1
+DUMP: 00000002: sha1=MDOWN-3 rev=-1

--- a/test/split2mono/svn-merge.test
+++ b/test/split2mono/svn-merge.test
@@ -1,0 +1,67 @@
+RUN: rm -rf %t.svn2git %t.split2mono
+RUN: mkdir %t.split2mono
+RUN: %svn2git create %t.svn2git
+RUN: %split2mono create %t.split2mono db
+
+# Create r1 and r3.  Note that setting the author timestamp with 'at' also
+# changes the default 'ct'.
+RUN: mkrepo %t-s
+RUN: mkrepo %t-m
+RUN: env at=1550000001 mkblob-svn -s %t-s -m %t-m -d sub 1
+RUN: git -C %t-m rev-list -1 master | xargs %svn2git insert %t.svn2git 1
+RUN: git -C %t-s branch r1
+RUN: env at=1550000003 mkblob-svn -s %t-s -m %t-m -d sub 3
+RUN: git -C %t-m rev-list -1 master | xargs %svn2git insert %t.svn2git 3
+RUN: git -C %t-s branch r3
+
+# Create a branch from r1, add a commit identical to r3 on top of a downstream
+# commit, and add another downstream commit.  This mimics having an extra-fast
+# cherry-pick as a parent.
+RUN: git -C %t-s checkout -b downstream r1
+RUN: env at=1550000002 mkblob %t-s 2
+RUN: env at=1550000004 mkmerge %t-s 4 r3
+
+# Give %t-m access to %t-s.
+RUN: git -C %t-m remote add s %t-s
+RUN: git -C %t-m remote update
+
+RUN: git -C %t-m apple-llvm mt list-commits sub s/downstream \
+RUN:   | %split2mono -C %t-m interleave-commits              \
+RUN:     %t.split2mono %t.svn2git                            \
+RUN:     0000000000000000000000000000000000000000            \
+RUN:     0000000000000000000000000000000000000000:sub >%t.out
+RUN: cat %t.out | awk '{print $1}' \
+RUN:   | xargs git -C %t-m update-ref downstream
+RUN: number-commits -p SUP   %t-s master                   >%t.map
+RUN: number-commits -p SDOWN %t-s downstream --not master >>%t.map
+RUN: number-commits -p MUP   %t-m master                  >>%t.map
+RUN: number-commits -p MDOWN %t-m downstream --not master >>%t.map
+RUN: git -C %t-m log downstream                            \
+RUN:       --format="--%%n%%H %%P %%s%%n%%(trailers:only)" \
+RUN:       --stat --name-status --date-order               \
+RUN:   | apply-commit-numbers %t.map | grep -e . | check-diff %s LOG %t
+LOG: --
+LOG: MDOWN-2 MDOWN-1 MUP-2 mkmerge: 4
+LOG: apple-llvm-split-commit: SDOWN-2
+LOG: apple-llvm-split-dir: sub/
+LOG: --
+LOG: MUP-2 MUP-1 mkblob-svn: r3
+LOG: llvm-svn: 3
+LOG: A sub/3
+LOG: --
+LOG: MDOWN-1 MUP-1 mkblob: 2
+LOG: apple-llvm-split-commit: SDOWN-1
+LOG: apple-llvm-split-dir: sub/
+LOG: A sub/2
+LOG: --
+LOG: MUP-1 mkblob-svn: r1
+LOG: llvm-svn: 1
+LOG: A sub/1
+RUN: cat %t.out | apply-commit-numbers %t.map | check-diff %s OUT %t
+OUT: MDOWN-2 SDOWN-2:sub
+RUN: %split2mono dump %t.split2mono | apply-commit-numbers %t.map \
+RUN:   | grep -e sha1= -e split= | check-diff %s DUMP %t
+DUMP: 00000000: split=SDOWN-1 mono=MDOWN-1
+DUMP: 00000001: split=SDOWN-2 mono=MDOWN-2
+DUMP: 00000000: sha1=MDOWN-1 rev=-1
+DUMP: 00000001: sha1=MDOWN-2 rev=-3


### PR DESCRIPTION
split2mono: Strengthen heuristic for detecting upstream git-svn commits

Improve the heuristic for detecting upstream git-svn commits.  Now we
only parse the commit metadata looking for `git-svn-id:` when (a) the
commit is not a merge, (b) the parent commit (if any) has not been
generated by split2mono, and (c) the author and committer info match
exactly.  Before this commit, the only check was (c).

This required some (perhaps overdue) refactoring of compute_rev to make
the logic for split commits and monorepo commits clear (and, in some
cases, different).  A few functions in `git_cache` were renamed for
clarity.

The tests use an invented history that looks like an LLVM subproject,
with `git-svn-id:` for the split commits and `llvm-rev:` for the
monorepo commits.
