### PR TITLE
mt-config: Add apple-v2, to generate a fresh history

### DIFF
--- a/mt-config/apple-v2.mt-config
+++ b/mt-config/apple-v2.mt-config
@@ -156,6 +156,14 @@ generate branch swift/swift-5.1-branch
 repeat swift/swift-5.1-branch      apple/stable/20190104
 dir    swift/swift-5.1-branch lldb split/apple/lldb/swift-5.1-branch
 
+# Generate apple/stable/20190619.
+dir apple/stable/20190619 -                 split/apple/root/apple/stable/20190619
+dir apple/stable/20190619 clang             split/apple/clang/apple/stable/20190619
+dir apple/stable/20190619 clang-tools-extra split/apple/clang-tools-extra/apple/stable/20190619
+dir apple/stable/20190619 compiler-rt       split/apple/compiler-rt/apple/stable/20190619
+dir apple/stable/20190619 libcxx            split/apple/libcxx/apple/stable/20190619
+dir apple/stable/20190619 llvm              split/apple/llvm/apple/stable/20190619
+
 # Generate swift/master from each split repo's stable branch, intended to be
 # paired with swift's master branch.
 #

--- a/mt-config/apple-v2.mt-config
+++ b/mt-config/apple-v2.mt-config
@@ -1,0 +1,190 @@
+repo github/llvm.org                   https://github.com/llvm/llvm-project.git
+repo split/llvm.org/clang              https://git.llvm.org/git/clang.git
+repo split/llvm.org/clang-tools-extra  https://git.llvm.org/git/clang-tools-extra.git
+repo split/llvm.org/compiler-rt        https://git.llvm.org/git/compiler-rt.git
+repo split/llvm.org/libcxx             https://git.llvm.org/git/libcxx.git
+repo split/llvm.org/lldb               https://git.llvm.org/git/lldb.git
+repo split/llvm.org/llvm               https://git.llvm.org/git/llvm.git
+repo split/apple/clang                 git@github.com:apple/swift-clang.git
+repo split/apple/clang-tools-extra     git@github.com:apple/swift-clang-tools-extra.git
+repo split/apple/compiler-rt           git@github.com:apple/swift-compiler-rt.git
+repo split/apple/libcxx                git@github.com:apple/swift-libcxx.git
+repo split/apple/lldb                  git@github.com:apple/swift-lldb.git
+repo split/apple/llvm                  git@github.com:apple/swift-llvm.git
+repo split/apple/root                  git@github.com:apple/llvm-monorepo-root.git
+repo github/apple/v2                   git@github.com:apple/llvm-project-v2.git
+repo github/apple/v2-split             git@github.com:apple/llvm-project-v2-split.git
+
+destination monorepo github/apple/v2
+destination splitref github/apple/v2-split
+
+declare-dir -
+declare-dir clang-tools-extra
+declare-dir clang
+declare-dir compiler-rt
+declare-dir debuginfo-tests
+declare-dir libclc
+declare-dir libcxx
+declare-dir libcxxabi
+declare-dir libunwind
+declare-dir lld
+declare-dir lldb
+declare-dir llgo
+declare-dir llvm
+declare-dir openmp
+declare-dir parallel-libs
+declare-dir polly
+declare-dir pstl
+
+# Map all the monorepo commits from llvm.org so they can be found (quickly) by
+# revision number.
+generate mapping github/llvm.org
+
+# As an optimization, track which refs in the split repos have already been
+# mapped.
+generate splitrefs github/llvm.org/master
+dir github/llvm.org/master clang             split/llvm.org/clang/master
+dir github/llvm.org/master clang-tools-extra split/llvm.org/clang-tools-extra/master
+dir github/llvm.org/master compiler-rt       split/llvm.org/compiler-rt/master
+dir github/llvm.org/master libcxx            split/llvm.org/libcxx/master
+dir github/llvm.org/master llvm              split/llvm.org/llvm/master
+dir github/llvm.org/master lldb              split/llvm.org/lldb/master
+
+# Generate apple/master from */upstream-with-swift, skipping LLDB since its
+# branch depends on the 'swift' repo.  See swift/master-next for LLDB's
+# upstream-with-swift branch.
+generate branch apple/master
+dir apple/master -                 split/apple/root/apple/master
+dir apple/master clang             split/apple/clang/upstream-with-swift
+dir apple/master clang-tools-extra split/apple/clang-tools-extra/upstream-with-swift
+dir apple/master compiler-rt       split/apple/compiler-rt/upstream-with-swift
+dir apple/master libcxx            split/apple/libcxx/upstream-with-swift
+dir apple/master llvm              split/apple/llvm/upstream-with-swift
+
+# Generate apple/stable/20160127 from swift-3.0-branch, skipping LLDB, and then
+# add LLDB to generate swift/swift-3.0-branch.
+generate branch apple/stable/20160127
+dir apple/stable/20160127 clang       split/apple/clang/swift-3.0-branch
+dir apple/stable/20160127 compiler-rt split/apple/compiler-rt/swift-3.0-branch
+dir apple/stable/20160127 llvm        split/apple/llvm/swift-3.0-branch
+
+generate branch swift/swift-3.0-branch
+repeat swift/swift-3.0-branch      apple/stable/20160127
+dir    swift/swift-3.0-branch lldb split/apple/lldb/swift-3.0-branch
+
+# Generate apple/stable/20160817 from swift-3.1-branch, skipping LLDB at first.
+generate branch apple/stable/20160817
+dir apple/stable/20160817 clang       split/apple/clang/swift-3.1-branch
+dir apple/stable/20160817 compiler-rt split/apple/compiler-rt/swift-3.1-branch
+dir apple/stable/20160817 llvm        split/apple/llvm/swift-3.1-branch
+
+generate branch swift/swift-3.1-branch
+repeat swift/swift-3.1-branch      apple/stable/20160817
+dir    swift/swift-3.1-branch lldb split/apple/lldb/swift-3.1-branch
+
+# Generate apple/stable/20170116 from swift-4.0-branch, skipping LLDB at first.
+generate branch apple/stable/20170116
+dir apple/stable/20170116 clang       split/apple/clang/swift-4.0-branch
+dir apple/stable/20170116 compiler-rt split/apple/compiler-rt/swift-4.0-branch
+dir apple/stable/20170116 llvm        split/apple/llvm/swift-4.0-branch
+
+generate branch swift/swift-4.0-branch
+repeat swift/swift-4.0-branch      apple/stable/20170116
+dir    swift/swift-4.0-branch lldb split/apple/lldb/swift-4.0-branch
+
+# Generate apple/stable/20170719 from swift-4.1-branch, skipping LLDB at first.
+generate branch apple/stable/20170719
+dir apple/stable/20170719 clang       split/apple/clang/swift-4.1-branch
+dir apple/stable/20170719 compiler-rt split/apple/compiler-rt/swift-4.1-branch
+dir apple/stable/20170719 llvm        split/apple/llvm/swift-4.1-branch
+
+# Generate the first part of swift/swift-4.1-branch, which merges in as a
+# second parent when the history gets "fixed".  Use '{no-pass}' to avoid
+# generating merges for clang/llvm/compiler-rt commits that should show up in
+# the next directive.
+generate branch archive/before-lldb-fix/swift/swift-4.1-branch
+repeat archive/before-lldb-fix/swift/swift-4.1-branch      apple/stable/20170719{no-pass}
+dir    archive/before-lldb-fix/swift/swift-4.1-branch lldb split/apple/lldb/archive/start/fixed/swift-4.1-branch
+
+# Finally generate swift/swift-4.1-branch with the rest of LLDB's history for
+# that branch.
+generate branch swift/swift-4.1-branch
+repeat swift/swift-4.1-branch      apple/stable/20170719
+dir    swift/swift-4.1-branch lldb split/apple/lldb/swift-4.1-branch
+
+# Generate apple/stable/20180103 from swift-4.2-branch, skipping LLDB at first.
+generate branch apple/stable/20180103
+dir apple/stable/20180103 clang       split/apple/clang/swift-4.2-branch
+dir apple/stable/20180103 compiler-rt split/apple/compiler-rt/swift-4.2-branch
+dir apple/stable/20180103 llvm        split/apple/llvm/swift-4.2-branch
+
+generate branch swift/swift-4.2-branch
+repeat swift/swift-4.2-branch      apple/stable/20180103
+dir    swift/swift-4.2-branch lldb split/apple/lldb/swift-4.2-branch
+
+# Generate apple/stable/20180719 from the archive.  This was the original
+# branch point for swift-5.0-branch, before it was recut, and the original
+# branch got hung-off the second parent.  No matching LLDB branch.
+generate branch apple/stable/20180719
+dir apple/stable/20180719 clang       split/apple/clang/archive/original/swift-5.0-branch
+dir apple/stable/20180719 compiler-rt split/apple/compiler-rt/archive/original/swift-5.0-branch
+dir apple/stable/20180719 llvm        split/apple/llvm/archive/original/swift-5.0-branch
+
+# Generate apple/stable/20180912 from swift-5.0-branch, skipping LLDB at first.
+# Note that the libcxx and clang-tools-extra directories gained changes here.
+generate branch apple/stable/20180801
+dir apple/stable/20180801 clang             split/apple/clang/swift-5.0-branch
+dir apple/stable/20180801 clang-tools-extra split/apple/clang-tools-extra/swift-5.0-branch
+dir apple/stable/20180801 compiler-rt       split/apple/compiler-rt/swift-5.0-branch
+dir apple/stable/20180801 libcxx            split/apple/libcxx/swift-5.0-branch
+dir apple/stable/20180801 llvm              split/apple/llvm/swift-5.0-branch
+
+generate branch swift/swift-5.0-branch
+repeat swift/swift-5.0-branch      apple/stable/20180801
+dir    swift/swift-5.0-branch lldb split/apple/lldb/swift-5.0-branch
+
+# Generate apple/stable/20190104 from swift-5.1-branch, skipping LLDB at first.
+generate branch apple/stable/20190104
+dir apple/stable/20190104 -                 split/apple/root/apple/stable/20190104
+dir apple/stable/20190104 clang             split/apple/clang/swift-5.1-branch
+dir apple/stable/20190104 clang-tools-extra split/apple/clang-tools-extra/swift-5.1-branch
+dir apple/stable/20190104 compiler-rt       split/apple/compiler-rt/swift-5.1-branch
+dir apple/stable/20190104 libcxx            split/apple/libcxx/swift-5.1-branch
+dir apple/stable/20190104 llvm              split/apple/llvm/swift-5.1-branch
+
+generate branch swift/swift-5.1-branch
+repeat swift/swift-5.1-branch      apple/stable/20190104
+dir    swift/swift-5.1-branch lldb split/apple/lldb/swift-5.1-branch
+
+# Generate swift/master from each split repo's stable branch, intended to be
+# paired with swift's master branch.
+#
+# Note: There are merges where the main history hangs off the second parent for
+# clang/llvm/compiler-rt (notably, the rebranches for 3.1, 4.0, and 4.1), but
+# it's hard to generate a meaningful history for those pieces because LLDB's
+# branching strategy differs from the rest.  For now (in this version of the
+# monorepo generation) don't try, but for future reference: these side
+# histories have branches in the split repos at
+# archive/start/stable/swift-3.1-branch, archive/start/stable/swift-4.0-branch,
+# and archive/start/stable/swift-4.1-branch.
+generate branch swift/master
+dir swift/master lldb              split/apple/lldb/stable
+dir swift/master clang             split/apple/clang/stable
+dir swift/master clang-tools-extra split/apple/clang-tools-extra/stable
+dir swift/master compiler-rt       split/apple/compiler-rt/stable
+dir swift/master libcxx            split/apple/libcxx/stable
+dir swift/master llvm              split/apple/llvm/stable
+
+# Generate swift/master-next from LLDB's upstream-with-swift branch and the
+# pre-existing apple/master branch.  This should give a similar result to
+# interleaving each repo's upstream-with-swift branch.
+#
+# Note: apple/master does not depend on the swift repo in any way, whereas
+# swift/master-next does and is intended to be paired with swift's master-next
+# branch.
+#
+# Note: this is done *last* because LLDB's upstream-with-swift branch is a
+# global merge sink for its other branches.
+generate branch swift/master-next
+repeat swift/master-next      apple/master
+dir    swift/master-next lldb split/apple/lldb/upstream-with-swift


### PR DESCRIPTION
The history in apple-v1 is corrupted, since a number of cherry-pick
commits were mis-identified as the original upstream commits.  Add a
configuration for apple-v2 so we can build a fresh history now that the
bugs in `split2mono` have been fixed.