### PR TITLE
split2mono: Fix a few problems with repeat directives

### DIFF
--- a/src/commit_interleaver.h
+++ b/src/commit_interleaver.h
@@ -326,9 +326,12 @@ int commit_interleaver::make_partial_tree(
     if (source.is_repeat) {
       for (int i = 0; i < tree.num_items; ++i) {
         assert(tree.items[i].sha1);
-        if (int d = dirs.find_dir(tree.items[i].name))
-          if (dirs.repeated_dirs.test(d))
-            items.push_back(tree.items[i]);
+        int d = dirs.find_dir(tree.items[i].name);
+        if (d == -1)
+          continue;
+        if (!dirs.repeated_dirs.test(d))
+          continue;
+        items.push_back(tree.items[i]);
       }
       return 0;
     }

--- a/src/commit_interleaver.h
+++ b/src/commit_interleaver.h
@@ -993,16 +993,20 @@ int commit_interleaver::merge_targets(MergeRequest &merge,
         return 1;
 
       std::vector<git_tree::item_type> items;
-      for (int i = 0; i < tree.num_items; ++i)
-        if (int d = dirs.find_dir(tree.items[i].name))
+      for (int i = 0; i < tree.num_items; ++i) {
+        int d = dirs.find_dir(tree.items[i].name);
+        if (d != -1)
           if (source.is_repeat ? dirs.repeated_dirs.test(d)
                                : dirs.list[d].is_root)
             items.push_back(tree.items[i]);
-      for (int i = 0; i < head_tree.num_items; ++i)
-        if (int d = dirs.find_dir(head_tree.items[i].name))
+      }
+      for (int i = 0; i < head_tree.num_items; ++i) {
+        int d = dirs.find_dir(head_tree.items[i].name);
+        if (d != -1)
           if (source.is_repeat ? dirs.repeated_dirs.test(d)
                                : dirs.list[d].is_root)
             items.push_back(head_tree.items[i]);
+      }
       // Sort and see if we're matched up pairwise.
       std::sort(items.begin(), items.end());
       if (items.size() % 2) {

--- a/src/git_cache.h
+++ b/src/git_cache.h
@@ -1076,8 +1076,8 @@ void git_cache::apply_merge_authorship(commit_tree_buffers &buffers,
                                        parsed_metadata::string_ref cd) {
   buffers.an.append("apple-llvm-mt");
   buffers.cn.append("apple-llvm-mt");
-  buffers.ae.append("mt @ apple-llvm");
-  buffers.ce.append("mt @ apple-llvm");
+  buffers.ae.append("mt@apple-llvm");
+  buffers.ce.append("mt@apple-llvm");
   buffers.ad.append(cd.first, cd.last);
   buffers.cd.append(cd.first, cd.last);
 }

--- a/test/mt-generate/Inputs/repeat-two-dirs.mt-config.in
+++ b/test/mt-generate/Inputs/repeat-two-dirs.mt-config.in
@@ -1,0 +1,23 @@
+repo r         file://%t-r
+repo a         file://%t-a
+repo b         file://%t-b
+repo c         file://%t-c
+repo out       file://%t-out
+repo out-split file://%t-out-split
+
+destination splitref out-split
+destination monorepo out
+
+declare-dir -
+declare-dir a
+declare-dir b
+declare-dir c
+
+generate branch rab
+generate branch rabc
+repeat          rabc rab
+
+dir rab  -    r/master
+dir rab  a    a/master
+dir rab  b    b/master
+dir rabc c    c/master

--- a/test/mt-generate/Inputs/root-merge-heads.mt-config.in
+++ b/test/mt-generate/Inputs/root-merge-heads.mt-config.in
@@ -1,0 +1,33 @@
+repo root      file://%t-root
+repo subs      file://%t-subs
+repo out       file://%t-out
+repo out-split file://%t-out-split
+
+destination splitref out-split
+destination monorepo out
+
+declare-dir -
+declare-dir subs
+
+generate branch just-subs
+generate branch nor5
+generate branch just-root
+generate branch both
+generate branch root-after-subs
+start           root-after-subs just-subs
+generate branch subs-after-root
+start           subs-after-root just-root
+generate branch nor5-and-subs
+start           nor5-and-subs both
+repeat          nor5-and-subs nor5
+
+dir subs-after-root subs subs/master
+dir root-after-subs subs subs/master
+dir just-subs       subs subs/master
+dir both            subs subs/master
+dir nor5-and-subs   subs subs/master
+dir subs-after-root -    root/master
+dir root-after-subs -    root/master
+dir just-root       -    root/master
+dir both            -    root/master
+dir nor5            -    root/nor5

--- a/test/mt-generate/repeat-root-2.test
+++ b/test/mt-generate/repeat-root-2.test
@@ -29,14 +29,27 @@ RUN: number-commits -p X2 %t.x           b1..b2 >>%t.map
 RUN: number-commits -p Y  %t.y           master >>%t.map
 RUN: number-commits -p R  %t.root        master >>%t.map
 RUN: git -C %t-mt-repo.git log b1 --topo-order --format="%%H %%P %%s" \
+RUN:     -m --name-status                                             \
 RUN:   | apply-commit-numbers %t.map | grep -e . | check-diff %s CHECK-B1 %t
 CHECK-B1: B1-4 B1-3 mkblob: x7
+CHECK-B1: A x/x7
 CHECK-B1: B1-3 B1-2 mkblob: r5
+CHECK-B1: A r5
 CHECK-B1: B1-2 B1-1 mkblob: r2
+CHECK-B1: A r2
 CHECK-B1: B1-1      mkblob: x1
+CHECK-B1: A x/x1
 RUN: git -C %t-mt-repo.git log b1..b2 --topo-order --format="%%H %%P %%s" \
+RUN:     -m --name-status                                                 \
 RUN:   | apply-commit-numbers %t.map | grep -e . | check-diff %s CHECK-B2 %t
 CHECK-B2: B2-4 B2-3                  mkblob: y6
+CHECK-B2: A y/y6
 CHECK-B2: B2-3 B2-2 B1-3 Merge root: mkblob: r5
+CHECK-B2: A r5
+CHECK-B2: B2-3 B2-2 B1-3 Merge root: mkblob: r5
+CHECK-B2: A x/x4
+CHECK-B2: A y/y3
 CHECK-B2: B2-2 B2-1                  mkblob: x4
+CHECK-B2: A x/x4
 CHECK-B2: B2-1 B1-2                  mkblob: y3
+CHECK-B2: A y/y3

--- a/test/mt-generate/repeat-root.test
+++ b/test/mt-generate/repeat-root.test
@@ -21,11 +21,24 @@ RUN: number-commits -p ADD-B  %t-mt-repo.git just-a..add-b >>%t.map
 RUN: number-commits -p A      %t.a              master     >>%t.map
 RUN: number-commits -p B      %t.b              master     >>%t.map
 RUN: git -C %t-mt-repo.git log add-b --topo-order --format="%%H %%P %%s" \
+RUN:     -m --name-status                                                \
 RUN:   | apply-commit-numbers %t.map | grep -e . | check-diff %s CHECK %t
 CHECK:  ADD-B-4  ADD-B-3 JUST-A-3 Merge root: mkblob: 5
+CHECK: A 5
+CHECK:  ADD-B-4  ADD-B-3 JUST-A-3 Merge root: mkblob: 5
+CHECK: A b/2
+CHECK: A b/4
 CHECK: JUST-A-3 JUST-A-2          mkblob: 5
+CHECK: A 5
 CHECK:  ADD-B-3  ADD-B-2          mkblob: 4
+CHECK: A b/4
 CHECK:  ADD-B-2  ADD-B-1 JUST-A-2 Merge root: mkblob: 3
+CHECK: A 3
+CHECK:  ADD-B-2  ADD-B-1 JUST-A-2 Merge root: mkblob: 3
+CHECK: A b/2
 CHECK: JUST-A-2 JUST-A-1          mkblob: 3
+CHECK: A 3
 CHECK:  ADD-B-1 JUST-A-1          mkblob: 2
+CHECK: A b/2
 CHECK: JUST-A-1                   mkblob: 1
+CHECK: A 1

--- a/test/mt-generate/repeat-two-dirs.test
+++ b/test/mt-generate/repeat-two-dirs.test
@@ -1,0 +1,54 @@
+RUN: mkrepo %t-r
+RUN: mkrepo %t-a
+RUN: mkrepo %t-b
+RUN: mkrepo %t-c
+RUN: env ct=1550000001 mkblob %t-a a1
+RUN: env ct=1550000002 mkblob %t-b b2
+RUN: env ct=1550000003 mkblob %t-c c3
+RUN: env ct=1550000004 mkblob %t-a a4
+RUN: env ct=1550000005 mkblob %t-b b5
+RUN: env ct=1550000006 mkblob %t-c c6
+RUN: env ct=1550000007 mkblob %t-r r7
+
+RUN: mkrepo --bare %t-out
+RUN: mkrepo --bare %t-out-split
+RUN: rm -rf %t-mt-repo.git
+RUN: rm -rf %t-mt-configs
+RUN: mkdir -p %t-mt-configs
+RUN: cat %S/Inputs/repeat-two-dirs.mt-config.in | sed -e 's,%%t,%t,' \
+RUN:   | tee %t-mt-configs/repeat-two-dirs.mt-config
+RUN: %mtgen --verbose --git-dir %t-mt-repo.git --config-dir %t-mt-configs \
+RUN:     repeat-two-dirs
+
+RUN: number-commits -p RAB  %t-mt-repo.git rab       >%t.map
+RUN: number-commits -p RABC %t-mt-repo.git rab..rabc >>%t.map
+RUN: git -C %t-mt-repo.git log rabc --date-order --format="%%H %%P %%s" \
+RUN:     -m --name-status                                               \
+RUN:   | apply-commit-numbers %t.map | grep -e . | check-diff %s CHECK %t
+CHECK: RABC-5 RABC-4 RAB-5 Merge root: mkblob: r7
+CHECK: A r7
+CHECK: RABC-5 RABC-4 RAB-5 Merge root: mkblob: r7
+CHECK: A c/c3
+CHECK: A c/c6
+CHECK: RAB-5  RAB-4        mkblob: r7
+CHECK: A r7
+CHECK: RABC-4 RABC-3       mkblob: c6
+CHECK: A c/c6
+CHECK: RABC-3 RABC-2 RAB-4 Merge b: mkblob: b5
+CHECK: A b/b5
+CHECK: RABC-3 RABC-2 RAB-4 Merge b: mkblob: b5
+CHECK: A c/c3
+CHECK: RAB-4  RAB-3        mkblob: b5
+CHECK: A b/b5
+CHECK: RABC-2 RABC-1 RAB-3 Merge a: mkblob: a4
+CHECK: A a/a4
+CHECK: RABC-2 RABC-1 RAB-3 Merge a: mkblob: a4
+CHECK: A c/c3
+CHECK: RAB-3  RAB-2        mkblob: a4
+CHECK: A a/a4
+CHECK: RABC-1 RAB-2        mkblob: c3
+CHECK: A c/c3
+CHECK: RAB-2  RAB-1        mkblob: b2
+CHECK: A b/b2
+CHECK: RAB-1               mkblob: a1
+CHECK: A a/a1

--- a/test/mt-generate/root-merge-heads.test
+++ b/test/mt-generate/root-merge-heads.test
@@ -1,0 +1,97 @@
+RUN: mkrepo %t-root
+RUN: mkrepo %t-subs
+RUN: env ct=1550000001 mkblob %t-root r1
+RUN: env ct=1550000002 mkblob %t-subs s2
+RUN: env ct=1550000003 mkblob %t-root r3
+RUN: git                   -C %t-root branch nor5
+RUN: env ct=1550000004 mkblob %t-subs s4
+RUN: env ct=1550000005 mkblob %t-root r5
+
+RUN: mkrepo --bare %t-out
+RUN: mkrepo --bare %t-out-split
+RUN: rm -rf %t-mt-repo.git
+RUN: rm -rf %t-mt-configs
+RUN: mkdir -p %t-mt-configs
+RUN: cat %S/Inputs/root-merge-heads.mt-config.in | sed -e 's,%%t,%t,' \
+RUN:   | tee %t-mt-configs/root-merge-heads.mt-config
+RUN: %mtgen --verbose --git-dir %t-mt-repo.git --config-dir %t-mt-configs \
+RUN:     root-merge-heads
+
+RUN: number-commits -p JUST-ROOT %t-mt-repo.git just-root        >%t.map
+RUN: number-commits -p JUST-SUBS %t-mt-repo.git just-subs       >>%t.map
+RUN: number-commits -p BOTH      %t-mt-repo.git both            >>%t.map \
+RUN:     --not just-root just-subs
+RUN: number-commits -p SUBS-2ND  %t-mt-repo.git subs-after-root >>%t.map \
+RUN:     --not just-root just-subs
+RUN: number-commits -p ROOT-2ND  %t-mt-repo.git root-after-subs >>%t.map \
+RUN:     --not just-root just-subs
+RUN: number-commits -p NOR5      %t-mt-repo.git nor5-and-subs   >>%t.map \
+RUN:     --not both root-after-subs subs-after-root
+RUN: git -C %t-mt-repo.git log both^@ --date-order --format="%%H %%P %%s" \
+RUN:     -m --name-status                                                 \
+RUN:   | apply-commit-numbers %t.map | grep -e . | check-diff %s SHARED %t
+RUN: git -C %t-mt-repo.git log subs-after-root^@ --date-order             \
+RUN:     --format="%%H %%P %%s"                                           \
+RUN:     -m --name-status                                                 \
+RUN:   | apply-commit-numbers %t.map | grep -e . | check-diff %s SHARED %t
+RUN: git -C %t-mt-repo.git log root-after-subs^@ --date-order             \
+RUN:     --format="%%H %%P %%s"                                           \
+RUN:     -m --name-status                                                 \
+RUN:   | apply-commit-numbers %t.map | grep -e . | check-diff %s SHARED %t
+SHARED: JUST-ROOT-3 JUST-ROOT-2          mkblob: r5
+SHARED: A r5
+SHARED: JUST-SUBS-2 JUST-SUBS-1          mkblob: s4
+SHARED: A subs/s4
+SHARED: JUST-ROOT-2 JUST-ROOT-1          mkblob: r3
+SHARED: A r3
+SHARED: JUST-SUBS-1                      mkblob: s2
+SHARED: A subs/s2
+SHARED: JUST-ROOT-1                      mkblob: r1
+SHARED: A r1
+
+RUN: git -C %t-mt-repo.git log both --date-order --format="%%H %%P %%s" \
+RUN:     -m --name-status --no-walk                                     \
+RUN:   | apply-commit-numbers %t.map | grep -e . | check-diff %s BOTH %t
+BOTH: BOTH-1 JUST-ROOT-3 JUST-SUBS-2   Merge root and subs
+BOTH: A subs/s2
+BOTH: A subs/s4
+BOTH: BOTH-1 JUST-ROOT-3 JUST-SUBS-2   Merge root and subs
+BOTH: A r1
+BOTH: A r3
+BOTH: A r5
+
+RUN: git -C %t-mt-repo.git log subs-after-root --date-order             \
+RUN:     --format="%%H %%P %%s"                                         \
+RUN:     -m --name-status --no-walk                                     \
+RUN:   | apply-commit-numbers %t.map | grep -e . | check-diff %s SUBS-2ND %t
+SUBS-2ND: SUBS-2ND-1 JUST-ROOT-3 JUST-SUBS-2   Merge subs: mkblob: s4
+SUBS-2ND: A subs/s2
+SUBS-2ND: A subs/s4
+SUBS-2ND: SUBS-2ND-1 JUST-ROOT-3 JUST-SUBS-2   Merge subs: mkblob: s4
+SUBS-2ND: A r1
+SUBS-2ND: A r3
+SUBS-2ND: A r5
+
+RUN: git -C %t-mt-repo.git log root-after-subs --date-order             \
+RUN:     --format="%%H %%P %%s"                                         \
+RUN:     -m --name-status --no-walk                                     \
+RUN:   | apply-commit-numbers %t.map | grep -e . | check-diff %s ROOT-2ND %t
+ROOT-2ND: ROOT-2ND-1 JUST-SUBS-2 JUST-ROOT-3   Merge root: mkblob: r5
+ROOT-2ND: A r1
+ROOT-2ND: A r3
+ROOT-2ND: A r5
+ROOT-2ND: ROOT-2ND-1 JUST-SUBS-2 JUST-ROOT-3   Merge root: mkblob: r5
+ROOT-2ND: A subs/s2
+ROOT-2ND: A subs/s4
+
+# This is not merging independent commits.  For the merge to be created
+# split2mono needs to notice the root content is wrong.
+RUN: git -C %t-mt-repo.git log nor5-and-subs --date-order               \
+RUN:     --format="%%H %%P %%s"                                         \
+RUN:     -m --name-status --no-walk                                     \
+RUN:   | apply-commit-numbers %t.map | grep -e . | check-diff %s NOR5 %t
+NOR5: NOR5-1 BOTH-1 JUST-ROOT-2 Merge root: mkblob: r3
+NOR5: D	r5
+NOR5: NOR5-1 BOTH-1 JUST-ROOT-2 Merge root: mkblob: r3
+NOR5: A subs/s2
+NOR5: A subs/s4

--- a/test/split2mono/repeat.test
+++ b/test/split2mono/repeat.test
@@ -108,6 +108,18 @@ AB: apple-llvm-split-dir: a/
 AB: --
 AB: ADD-B-3 ADD-B-2 JUST-A-2 Merge a: mkblob: 4
 AB: apple-llvm-split-dir: a/
+
+# Check metadata for the merge commit.
+RUN: git -C %t-ab log --no-walk add-b                      \
+RUN:      --format=%%an%%n%%cn%%n%%ae%%n%%ce%%n%%at%%n%%ct \
+RUN:   | check-diff %s METADATA %t
+METADATA: apple-llvm-mt
+METADATA: apple-llvm-mt
+METADATA: mt@apple-llvm
+METADATA: mt@apple-llvm
+METADATA: 1550000004
+METADATA: 1550000004
+
 AB-BODY: --
 AB-BODY: ADD-B-3
 AB-BODY: Merge a: mkblob: 4


### PR DESCRIPTION
Two bug fixes and two cosmetic changes for generated `repeat` merges.
- Fix content for generated merges of root directory commits.
- Fix octopus merges of heads involving the root directory.
- Prune the list of directories in generated repeat merges to just those that have changes.
- Change the generated merge email to `mt@apple-llvm`, dropping spaces.