### PR TITLE
mt-generate: Run git-pack-refs to speed up fresh clones

### DIFF
--- a/libexec/apple-llvm/git-apple-llvm-mt-generate
+++ b/libexec/apple-llvm/git-apple-llvm-mt-generate
@@ -294,6 +294,9 @@ mt_setup() {
         error "failed to sync '$GIT_DIR'"
     done || return 1
 
+    # Pack refs for faster rev-parse queries.
+    run git pack-refs --all || return 1
+
     # Check that the destination repos work.
     run git remote | run grep "$splitdest" >/dev/null ||
         error "splitref destination '$splitdest' is not a repo"


### PR DESCRIPTION
This speeds up the tool substantially, when running on a fresh clone.  I'm still seeing inconsistent exit status from `git rev-parse --verify $1^{commit}`, where it sometimes fails on fresh clones (but a later call gets a non-zero status), but this speedup will help a lot regardless.