### PR TITLE
mt-generate: Ensure that `repeat` is a no-op when it should be

### DIFF
--- a/libexec/apple-llvm/git-apple-llvm-mt-generate
+++ b/libexec/apple-llvm/git-apple-llvm-mt-generate
@@ -25,6 +25,10 @@ usage() {
         "   --check-for-work"                                                 \
         "                   Print the first piece of work to do, but"         \
         "                   don't actually do anything"                       \
+        "   --assume-branch-work"                                             \
+        "                   Meant for testing, assume there is work to do on" \
+        "                   a branch (don't return early).  Forces a call to" \
+        "                   mt-translate-ref."                                \
         "   --sync-destinations"                                              \
         "                   Sync destinations repeatedly until there is no"   \
         "                   work to do, relying on another agent to push it;" \
@@ -793,8 +797,9 @@ mt_generate_ref() {
         # Not reachable...
     done
 
-    # Return early unless there's work to do.
-    [ -n "$work" ] || return 0
+    # Return early unless there's work to do, or unless tests have asked to
+    # bypass this early return.
+    assume_branch_work || [ -n "$work" ] || return 0
 
     refdirs="$(print_all_refdirs "$rawtarget")" ||
         error "failed to extract complete refdirs for $rawtarget"
@@ -964,6 +969,7 @@ should_push() { [ ! "${PUSH:-0}" = 0 ]; }
 push_only() { [ ! "${PUSH_ONLY:-0}" = 0 ]; }
 only_validate() { [ ! "${ONLY_VALIDATE:-0}" = 0 ]; }
 check_for_work() { [ ! "${CHECK_FOR_WORK:-0}" = 0 ]; }
+assume_branch_work() { [ ! "${ASSUME_BRANCH_WORK:-0}" = 0 ]; }
 should_sync_destinations() { [ ! "${SYNC:-0}" = 0 ]; }
 NAME=
 while [ $# -gt 0 ]; do
@@ -994,6 +1000,7 @@ while [ $# -gt 0 ]; do
         --generate)     GENERATE=1; shift ;;
         --no-generate)  GENERATE=0; shift ;;
         --check-for-work) CHECK_FOR_WORK=1; shift ;;
+        --assume-branch-work) ASSUME_BRANCH_WORK=1; shift ;;
         --dump-merged-mt-config) DUMP=merged; shift ;;
         --dump-mt-config)        DUMP=raw;    shift ;;
         --sync-destinations) SYNC=1; CHECK_FOR_WORK=1; shift ;;

--- a/src/commit_interleaver.h
+++ b/src/commit_interleaver.h
@@ -1001,9 +1001,10 @@ int commit_interleaver::merge_targets(MergeRequest &merge,
       if (source.is_repeat) {
         if (merge.head_is_independent) {
           // If we have a head, look up what's getting merged in.
-          if (ls_tree_head() ||
-              compare_trees(source, head_tree, target.mono, changed_dirs))
-            return 1;
+          if (!changed_dirs.any())
+            if (ls_tree_head() ||
+                compare_trees(source, head_tree, target.mono, changed_dirs))
+              return 1;
           for (int d = 0, de = dirs.list.size(); d != de; ++d)
             if (changed_dirs.test(d))
               source_dir_names.push_back(dirs.list[d].name);

--- a/src/dir_list.h
+++ b/src/dir_list.h
@@ -49,6 +49,7 @@ struct dir_name_range {
 
   const char *const *begin() const { return only ? &only : first; }
   const char *const *end() const { return only ? &only + 1 : last; }
+  bool empty() const { return begin() == end(); }
 };
 
 struct dir_type {

--- a/test/mt-generate/Inputs/repeat-two-dirs.mt-config.in
+++ b/test/mt-generate/Inputs/repeat-two-dirs.mt-config.in
@@ -15,9 +15,12 @@ declare-dir c
 
 generate branch rab
 generate branch rabc
-repeat          rabc rab
+generate branch rabc-downstream
+repeat          rabc            rab
+repeat          rabc-downstream rabc
 
-dir rab  -    r/master
-dir rab  a    a/master
-dir rab  b    b/master
-dir rabc c    c/master
+dir rab             -    r/master
+dir rab             a    a/master
+dir rab             b    b/master
+dir rabc            c    c/master
+dir rabc-downstream c    c/downstream

--- a/test/mt-generate/repeat-two-dirs.test
+++ b/test/mt-generate/repeat-two-dirs.test
@@ -7,7 +7,8 @@ RUN: env ct=1550000002 mkblob %t-b b2
 RUN: env ct=1550000003 mkblob %t-c c3
 RUN: env ct=1550000004 mkblob %t-a a4
 RUN: env ct=1550000005 mkblob %t-b b5
-RUN: env ct=1550000006 mkblob %t-c c6
+RUN: git -C %t-c checkout -b downstream
+RUN: env ct=1550000006 mkblob %t-c c6-downstream
 RUN: env ct=1550000007 mkblob %t-r r7
 
 RUN: mkrepo --bare %t-out
@@ -20,35 +21,113 @@ RUN:   | tee %t-mt-configs/repeat-two-dirs.mt-config
 RUN: %mtgen --verbose --git-dir %t-mt-repo.git --config-dir %t-mt-configs \
 RUN:     repeat-two-dirs
 
-RUN: number-commits -p RAB  %t-mt-repo.git rab       >%t.map
-RUN: number-commits -p RABC %t-mt-repo.git rab..rabc >>%t.map
-RUN: git -C %t-mt-repo.git log rabc --date-order --format="%%H %%P %%s" \
-RUN:     -m --name-status                                               \
-RUN:   | apply-commit-numbers %t.map | grep -e . | check-diff %s CHECK %t
-CHECK: RABC-5 RABC-4 RAB-5 Merge root: mkblob: r7
-CHECK: A r7
-CHECK: RABC-5 RABC-4 RAB-5 Merge root: mkblob: r7
-CHECK: A c/c3
-CHECK: A c/c6
-CHECK: RAB-5  RAB-4        mkblob: r7
-CHECK: A r7
-CHECK: RABC-4 RABC-3       mkblob: c6
-CHECK: A c/c6
-CHECK: RABC-3 RABC-2 RAB-4 Merge b: mkblob: b5
-CHECK: A b/b5
-CHECK: RABC-3 RABC-2 RAB-4 Merge b: mkblob: b5
-CHECK: A c/c3
-CHECK: RAB-4  RAB-3        mkblob: b5
-CHECK: A b/b5
-CHECK: RABC-2 RABC-1 RAB-3 Merge a: mkblob: a4
-CHECK: A a/a4
-CHECK: RABC-2 RABC-1 RAB-3 Merge a: mkblob: a4
-CHECK: A c/c3
-CHECK: RAB-3  RAB-2        mkblob: a4
-CHECK: A a/a4
-CHECK: RABC-1 RAB-2        mkblob: c3
-CHECK: A c/c3
-CHECK: RAB-2  RAB-1        mkblob: b2
-CHECK: A b/b2
-CHECK: RAB-1               mkblob: a1
-CHECK: A a/a1
+RUN: number-commits -p RAB  %t-mt-repo.git rab                    >%t.map
+RUN: number-commits -p RABC %t-mt-repo.git rab..rabc             >>%t.map
+RUN: number-commits -p DOWN %t-mt-repo.git rabc..rabc-downstream >>%t.map
+RUN: git -C %t-mt-repo.git log rabc --date-order \
+RUN:     --format="%%H %%P %%s" -m --name-status \
+RUN:   | apply-commit-numbers %t.map | grep -e . | check-diff %s RABC %t
+RABC: RABC-4 RABC-3 RAB-5 Merge root: mkblob: r7
+RABC: A r7
+RABC: RABC-4 RABC-3 RAB-5 Merge root: mkblob: r7
+RABC: A c/c3
+RABC: RAB-5  RAB-4        mkblob: r7
+RABC: A r7
+RABC: RABC-3 RABC-2 RAB-4 Merge b: mkblob: b5
+RABC: A b/b5
+RABC: RABC-3 RABC-2 RAB-4 Merge b: mkblob: b5
+RABC: A c/c3
+RABC: RAB-4  RAB-3        mkblob: b5
+RABC: A b/b5
+RABC: RABC-2 RABC-1 RAB-3 Merge a: mkblob: a4
+RABC: A a/a4
+RABC: RABC-2 RABC-1 RAB-3 Merge a: mkblob: a4
+RABC: A c/c3
+RABC: RAB-3  RAB-2        mkblob: a4
+RABC: A a/a4
+RABC: RABC-1 RAB-2        mkblob: c3
+RABC: A c/c3
+RABC: RAB-2  RAB-1        mkblob: b2
+RABC: A b/b2
+RABC: RAB-1               mkblob: a1
+RABC: A a/a1
+
+RUN: git -C %t-mt-repo.git log rabc-downstream --date-order \
+RUN:     --format="%%H %%P %%s" -m --name-status            \
+RUN:   | apply-commit-numbers %t.map | grep -e . | check-diff %s DOWN %t
+DOWN: DOWN-2 DOWN-1 RABC-4 Merge root: Merge root: mkblob: r7
+DOWN: A r7
+DOWN: DOWN-2 DOWN-1 RABC-4 Merge root: Merge root: mkblob: r7
+DOWN: A c/c6-downstream
+DOWN: RABC-4 RABC-3 RAB-5 Merge root: mkblob: r7
+DOWN: A r7
+DOWN: RABC-4 RABC-3 RAB-5 Merge root: mkblob: r7
+DOWN: A c/c3
+DOWN: RAB-5  RAB-4        mkblob: r7
+DOWN: A r7
+DOWN: DOWN-1 RABC-3       mkblob: c6-downstream
+DOWN: A c/c6-downstream
+DOWN: RABC-3 RABC-2 RAB-4 Merge b: mkblob: b5
+DOWN: A b/b5
+DOWN: RABC-3 RABC-2 RAB-4 Merge b: mkblob: b5
+DOWN: A c/c3
+DOWN: RAB-4  RAB-3        mkblob: b5
+DOWN: A b/b5
+DOWN: RABC-2 RABC-1 RAB-3 Merge a: mkblob: a4
+DOWN: A a/a4
+DOWN: RABC-2 RABC-1 RAB-3 Merge a: mkblob: a4
+DOWN: A c/c3
+DOWN: RAB-3  RAB-2        mkblob: a4
+DOWN: A a/a4
+DOWN: RABC-1 RAB-2        mkblob: c3
+DOWN: A c/c3
+DOWN: RAB-2  RAB-1        mkblob: b2
+DOWN: A b/b2
+DOWN: RAB-1               mkblob: a1
+DOWN: A a/a1
+
+# Add an extra commit that should not be repeated.  Drop down to
+# mt-translate-ref to avoid relying on mt-generate's early return logic by
+# using --assume-branch-work.
+RUN: git -C %t-c checkout master
+RUN: env ct=1550000008 mkblob %t-c c8
+RUN: %mtgen --verbose --git-dir %t-mt-repo.git --config-dir %t-mt-configs \
+RUN:     --assume-branch-work                                             \
+RUN:     repeat-two-dirs
+
+RUN: number-commits -p RAB  %t-mt-repo.git rab                    >%t.map
+RUN: number-commits -p RABC %t-mt-repo.git rab..rabc             >>%t.map
+RUN: number-commits -p DOWN %t-mt-repo.git rabc..rabc-downstream >>%t.map
+RUN: git -C %t-mt-repo.git log rabc --date-order \
+RUN:     --format="%%H %%P %%s" -m --name-status \
+RUN:   | apply-commit-numbers %t.map | grep -e . | check-diff %s RABC-WITH-C8 %t
+RABC-WITH-C8: RABC-5 RABC-4       mkblob: c8
+RABC-WITH-C8: A c/c8
+RABC-WITH-C8: RABC-4 RABC-3 RAB-5 Merge root: mkblob: r7
+RABC-WITH-C8: A r7
+RABC-WITH-C8: RABC-4 RABC-3 RAB-5 Merge root: mkblob: r7
+RABC-WITH-C8: A c/c3
+RABC-WITH-C8: RAB-5  RAB-4        mkblob: r7
+RABC-WITH-C8: A r7
+RABC-WITH-C8: RABC-3 RABC-2 RAB-4 Merge b: mkblob: b5
+RABC-WITH-C8: A b/b5
+RABC-WITH-C8: RABC-3 RABC-2 RAB-4 Merge b: mkblob: b5
+RABC-WITH-C8: A c/c3
+RABC-WITH-C8: RAB-4  RAB-3        mkblob: b5
+RABC-WITH-C8: A b/b5
+RABC-WITH-C8: RABC-2 RABC-1 RAB-3 Merge a: mkblob: a4
+RABC-WITH-C8: A a/a4
+RABC-WITH-C8: RABC-2 RABC-1 RAB-3 Merge a: mkblob: a4
+RABC-WITH-C8: A c/c3
+RABC-WITH-C8: RAB-3  RAB-2        mkblob: a4
+RABC-WITH-C8: A a/a4
+RABC-WITH-C8: RABC-1 RAB-2        mkblob: c3
+RABC-WITH-C8: A c/c3
+RABC-WITH-C8: RAB-2  RAB-1        mkblob: b2
+RABC-WITH-C8: A b/b2
+RABC-WITH-C8: RAB-1               mkblob: a1
+RABC-WITH-C8: A a/a1
+
+RUN: git -C %t-mt-repo.git log rabc-downstream --date-order \
+RUN:     --format="%%H %%P %%s" -m --name-status            \
+RUN:   | apply-commit-numbers %t.map | grep -e . | check-diff %s DOWN %t


### PR DESCRIPTION
`mt-translate-ref` is sometimes (but rarely) called when there are new
commits on the branch getting repeated, but none of them affect the
"repeated" dirs.  Ensure that we don't generate merge commits for those,
since it makes the history extra confusing (even without this change,
the content was correct).

As a drive-by, avoid comparing trees twice.