### PR TITLE
mt-generate: Push new refs even if they are aliases

### DIFF
--- a/libexec/apple-llvm/git-apple-llvm-mt-generate
+++ b/libexec/apple-llvm/git-apple-llvm-mt-generate
@@ -568,6 +568,7 @@ mt_generate() {
     fi
 
     # Invoke through wrappers whose logic can be reused.
+    local should_push_ref=true
     mt_fetcher   "$fetcher"   "$object" || exit 1
     mt_generator "$generator" "$object" || exit 1
     mt_pusher    "$pusher"    "$object" || exit 1
@@ -695,8 +696,12 @@ mt_push_tag()        { mt_push_ref "$@"; }
 
 mt_generate_ref() {
     # From parent: local action
+    # From parent: local should_push_ref
     local mtname refsprefix mtprefix target rawtarget="$1" mttype="$action"
     mt_ref_init_helper
+
+    # Assume we don't have to push.
+    should_push_ref=false
 
     # Check if the ref exists already.
     local work
@@ -804,6 +809,7 @@ mt_generate_ref() {
     refdirs="$(print_all_refdirs "$rawtarget")" ||
         error "failed to extract complete refdirs for $rawtarget"
 
+    should_push_ref=true
     run --dry git apple-llvm mt translate-ref $target "$start" $refdirs ||
         error "failed to generate $mttype '$target'"
 }
@@ -857,16 +863,16 @@ mt_fetch_one_branch() {
 
 mt_push_ref() {
     # From parent: local mttype
+    # From parent: local should_push_ref
     local mtname refsprefix mtprefix target rawtarget="$1" mttype="$action"
     mt_ref_init_helper
+
+    # Return early if there was no work.
+    $should_push_ref || return 0
 
     local branch="$1"
     local old_mtdb_sha1=$MTDB_SHA1
     MTDB_SHA1=$(run git show-ref $MTDB_REF | awk '{print $1}')
-
-    # Return early if nothing has changed.
-    [ ! "$old_mtdb_sha1" = "$MTDB_SHA1" ] ||
-        return 0
 
     # Push the primary refs.  Need to push to the local mirror, and then from
     # there to the actual remote.

--- a/test/mt-generate/Inputs/alias-branch.mt-config.in
+++ b/test/mt-generate/Inputs/alias-branch.mt-config.in
@@ -1,0 +1,13 @@
+repo in file://%t.in
+repo out file://%t.out
+repo out-split file://%t.out-split
+
+destination splitref out-split
+destination monorepo out
+
+declare-dir d
+
+generate branch d1
+generate branch d2
+dir d1 d in/master
+dir d2 d in/master

--- a/test/mt-generate/alias-branch.test
+++ b/test/mt-generate/alias-branch.test
@@ -1,0 +1,18 @@
+RUN: mkrepo %t.in
+RUN: env ct=1550000001 mkblob %t.in blob
+
+RUN: mkrepo --bare %t.out
+RUN: mkrepo --bare %t.out-split
+RUN: rm -rf %t-mt-repo.git
+RUN: rm -rf %t-mt-configs
+RUN: mkdir -p %t-mt-configs
+RUN: cat         %S/Inputs/alias-branch.mt-config.in | sed -e 's,%%t,%t,' \
+RUN:   | tee %t-mt-configs/alias-branch.mt-config
+RUN: %mtgen --git-dir %t-mt-repo.git --config-dir %t-mt-configs alias-branch
+
+RUN: number-commits -p D %t.out d1 >%t.map
+RUN: git -C %t.out log d1 --format="%%H %%P %%s" \
+RUN:   | apply-commit-numbers %t.map | grep -e . | check-diff %s CHECK %t
+RUN: git -C %t.out log d2 --format="%%H %%P %%s" \
+RUN:   | apply-commit-numbers %t.map | grep -e . | check-diff %s CHECK %t
+CHECK: D-1 mkblob: blob


### PR DESCRIPTION
Before the big `split2mono` rewrite over the last couple of weeks, if no
new commits were translated that meant we wouldn't create a ref.  Now we
do, and we need to push it.