### PR TITLE
split2mono: Add support for `apple-llvm-monorepo-commit:` trailers

### DIFF
--- a/libexec/apple-llvm/helpers/mt_split2mono.sh
+++ b/libexec/apple-llvm/helpers/mt_split2mono.sh
@@ -13,21 +13,8 @@ mt_split2mono() {
     local split2mono
     split2mono="$(build_executable split2mono)" ||
         error "could not build or find split2mono"
-    run "$split2mono" lookup "$MT_DB_SPLIT2MONO_DB" "$split"
-    [ $? -eq 0 ] && return 0
-
-    # FIXME: This could be too slow.  Instead of requiring a double lookup, we
-    # should consider moving this logic to mt_split2mono_translate_commit and
-    # saving this.  The upside of the current approach is that we avoid
-    # bloating split2mono.db with 200k+ extra commits.  Bloating the DB could
-    # slow down accesses, as well as adding overhead when creating, extracting,
-    # and transferring the refs.
-    local rev
-    if rev=$(mt_llvm_svn "$split"); then
-        mt_llvm_svn2git $rev
-        return $?
-    fi
-    return 1
+    run "$split2mono" compute-mono "$MT_DB_SPLIT2MONO_DB" "$MT_DB_SVN2GIT_DB" \
+        "$split"
 }
 
 mt_split2mono_insert() {

--- a/test/bin/mkblob
+++ b/test/bin/mkblob
@@ -4,6 +4,7 @@
 
 REPO="$1"
 BLOB="$2"
+shift 2
 
 [ -d "$REPO" ] || error "no such repo: '$REPO'"
 [ -d "$REPO"/.git ] || error "invalid repo: '$REPO'"
@@ -14,5 +15,12 @@ check mkdir -p "$(dirname "$FILE")"
 check printf "%s\n" "$BLOB" > "$FILE"
 check cd "$REPO"
 check git add "$BLOB"
-execdir --check mkcommit "$REPO" -am \
-    "$(printf "%s\n\n%s\n" "mkblob: $BLOB" "added the blob $BLOB")"
+
+if [ $# -eq 0 ]; then
+    MSG="$(printf "%s\n\n%s\n" "mkblob: $BLOB" "added the blob $BLOB")"
+    ARGS=( -m "$MSG" )
+else
+    ARGS=( "$@" )
+fi
+
+execdir --check mkcommit "$REPO" -a "${ARGS[@]}"

--- a/test/bin/test/mkblob.test
+++ b/test/bin/test/mkblob.test
@@ -15,11 +15,11 @@ RUN: mkrepo %t
 RUN: not git -C %t log | check-empty
 RUN: not mkblob %t
 RUN: mkblob %t a
-RUN: cat %t/a | check-diff %s BLOB %t
+RUN: cat %t/a | check-diff %s A %t
+A: a
 RUN: git -C %t log --date=raw \
 RUN:      --format=format:%%an%%n%%cn%%n%%ae%%n%%ce%%n%%ad%%n%%cd%%n%%B \
 RUN:   | check-diff %s LOG %t
-BLOB: a
 LOG: mkblob.sh
 LOG: mkblob.sh
 LOG: mkblob@apple.llvm
@@ -32,3 +32,22 @@ LOG: added the blob a
 
 RUN: not mkblob %t a 2>&1 | check-diff %s DUPLICATE %t
 DUPLICATE: error: blob already exists: 'a'
+
+# Customize message.
+RUN: mkblob %t b -m "my message"
+RUN: cat %t/b | check-diff %s B %t
+B: b
+RUN: git -C %t log --no-walk --format=format:%B | check-diff %s BMSG %t
+BMSG: my message
+
+# Customize message in file.
+RUN: echo "subject"  >%t.msg
+RUN: echo ""        >>%t.msg
+RUN: echo "body"    >>%t.msg
+RUN: mkblob %t c -F %t.msg
+RUN: cat %t/c | check-diff %s C %t
+C: c
+RUN: git -C %t log --no-walk --format=format:%B | check-diff %s CMSG %t
+CMSG: subject
+CMSG:
+CMSG: body

--- a/test/split2mono/insert-one.test
+++ b/test/split2mono/insert-one.test
@@ -1,9 +1,24 @@
-RUN: rm -rf %t.db
+RUN: rm -rf %t.db %t.svndb
 RUN: mkdir %t.db
+RUN: %svn2git create %t.svndb
 RUN: %split2mono create %t.db db
 RUN: %split2mono insert %t.db 0123456789abcdef0123456789abcdef01234567 9876543210abcdef0123456789abcdef01234567
-RUN: %split2mono lookup %t.db 0123456789abcdef0123456789abcdef01234567 | grep ^9876543210abcdef0123456789abcdef01234567'$'
-RUN: %split2mono dump %t.db | grep "split=0123456789abcdef0123456789abcdef01234567 mono=9876543210abcdef0123456789abcdef01234567"
+RUN: %split2mono lookup %t.db 0123456789abcdef0123456789abcdef01234567 | check-diff %s LOOKUP %t
+RUN: %split2mono compute-mono %t.db %t.svndb 0123456789abcdef0123456789abcdef01234567 \
+RUN:     | check-diff %s LOOKUP %t
+LOOKUP: 9876543210abcdef0123456789abcdef01234567
+
+RUN: %split2mono dump %t.db | check-diff %s DUMP %t
+DUMP: commits table
+DUMP:   00000000: split=0123456789abcdef0123456789abcdef01234567 mono=9876543210abcdef0123456789abcdef01234567
+DUMP:
+DUMP: commits index num=root num-bits=14
+DUMP:   entry: bits=00000001001000 table=00000000
+DUMP:
+DUMP: svnbase table
+DUMP:   <empty>
+DUMP:
+
 
 RUN: not %split2mono lookup %t.db 9876543210abcdef0123456789abcdef01234567 \
 RUN:   | check-empty

--- a/test/split2mono/insert-upstream.test
+++ b/test/split2mono/insert-upstream.test
@@ -1,5 +1,6 @@
-RUN: rm -rf %t-up.db %t-down.db
+RUN: rm -rf %t-up.db %t-down.db %t-svn.db
 RUN: mkdir %t-up.db %t-down.db
+RUN: %svn2git create %t-svn.db
 RUN: %split2mono create %t-up.db up
 RUN: %split2mono insert %t-up.db 0123456789abcdef0123456789abcdef01234567 \
 RUN:                             9876543210abcdef0123456789abcdef01234567
@@ -24,6 +25,10 @@ RUN: %split2mono lookup %t-up.db   0123456789abcdef0123456789abcdef01234567 \
 RUN:   | check-diff %s LOOKUP %t
 RUN: %split2mono lookup %t-down.db 0123456789abcdef0123456789abcdef01234567 \
 RUN:   | check-diff %s LOOKUP %t
+RUN: %split2mono compute-mono %t-up.db   %t-svn.db 0123456789abcdef0123456789abcdef01234567 \
+RUN:   | check-diff %s LOOKUP %t
+RUN: %split2mono compute-mono %t-down.db %t-svn.db 0123456789abcdef0123456789abcdef01234567 \
+RUN:   | check-diff %s LOOKUP %t
 LOOKUP: 9876543210abcdef0123456789abcdef01234567
 
 RUN: %split2mono dump %t-up.db   | grep -v entry: | grep -v index | grep . \
@@ -38,6 +43,8 @@ DUMP:   <empty>
 RUN: %split2mono insert %t-down.db 2123456789abcdef0123456789abcdef01234567 \
 RUN:                               2876543210abcdef0123456789abcdef01234567
 RUN: %split2mono lookup %t-down.db 2123456789abcdef0123456789abcdef01234567 \
+RUN:   | check-diff %s LOOKUP-2 %t
+RUN: %split2mono compute-mono %t-down.db %t-svn.db 2123456789abcdef0123456789abcdef01234567 \
 RUN:   | check-diff %s LOOKUP-2 %t
 LOOKUP-2: 2876543210abcdef0123456789abcdef01234567
 RUN: %split2mono dump %t-down.db | grep -v entry: | grep -v index | grep . \
@@ -65,6 +72,12 @@ RUN:   | check-diff %s LOOKUP %t
 RUN: %split2mono lookup %t-down.db 2123456789abcdef0123456789abcdef01234567 \
 RUN:   | check-diff %s LOOKUP-2 %t
 RUN: %split2mono lookup %t-down.db 3123456789abcdef0123456789abcdef01234567 \
+RUN:   | check-diff %s LOOKUP-3 %t
+RUN: %split2mono compute-mono %t-down.db %t-svn.db 0123456789abcdef0123456789abcdef01234567 \
+RUN:   | check-diff %s LOOKUP %t
+RUN: %split2mono compute-mono %t-down.db %t-svn.db 2123456789abcdef0123456789abcdef01234567 \
+RUN:   | check-diff %s LOOKUP-2 %t
+RUN: %split2mono compute-mono %t-down.db %t-svn.db 3123456789abcdef0123456789abcdef01234567 \
 RUN:   | check-diff %s LOOKUP-3 %t
 LOOKUP-3: 3876543210abcdef0123456789abcdef01234567
 RUN: %split2mono dump %t-up.db | grep -v entry: | grep -v index | grep . \

--- a/test/split2mono/svn-compute-mono.test
+++ b/test/split2mono/svn-compute-mono.test
@@ -1,0 +1,52 @@
+RUN: rm -rf %t.svn2git %t.split2mono
+RUN: mkdir %t.split2mono
+RUN: %svn2git create %t.svn2git
+RUN: %split2mono create %t.split2mono db
+
+# Create r1 and r3.  Note that setting the author timestamp with 'at' also
+# changes the default 'ct'.
+RUN: mkrepo %t-s
+RUN: mkrepo %t-m
+RUN: env at=1550000001 mkblob-svn -s %t-s -m %t-m -d sub 1
+RUN: git -C %t-m rev-list -1 master | xargs %svn2git insert %t.svn2git 1
+RUN: git -C %t-s branch r1
+RUN: env at=1550000003 mkblob-svn -s %t-s -m %t-m -d sub 3
+RUN: git -C %t-m rev-list -1 master | xargs %svn2git insert %t.svn2git 3
+RUN: git -C %t-s branch r3
+
+# Create an upstream commit post-SVN, using the expected trailers for an
+# upstream llvm.org commit.
+RUN: env at=1550000010 mkblob %t-m sub/10
+RUN: printf "10\n\n"                              >%t-10.msg
+RUN: printf "apple-llvm-monorepo-commit: "       >>%t-10.msg
+RUN: git -C %t-m log --no-walk --format=%H       >>%t-10.msg
+RUN: printf "apple-llvm-split-parents: "         >>%t-10.msg
+RUN: git -C %t-s log --no-walk --format=%H       >>%t-10.msg
+RUN: printf "apple-llvm-upstream-merge-base: "   >>%t-10.msg
+RUN: git -C %t-m log --no-walk --format=%H       >>%t-10.msg
+RUN: env at=1550000010 mkblob %t-s 10 -F %t-10.msg
+RUN: git -C %t-s branch r10
+
+# Add a cherry-pick of r10 onto r1.  It should be rejected.
+RUN: git -C %t-s checkout -b downstream r1
+RUN: env at=1550000010 git -C %t-s cherry-pick r10
+
+RUN: number-commits -p SUP   %t-s master      >%t.map
+RUN: number-commits -p MUP   %t-m master     >>%t.map
+RUN: number-commits -p SDOWN %t-s downstream >>%t.map
+
+RUN: git -C %t-s log --no-walk --format=%H r1                            \
+RUN:   | xargs %split2mono -C %t-s compute-mono %t.split2mono %t.svn2git \
+RUN:   | apply-commit-numbers %t.map | check-diff %s R1 %t
+R1: MUP-1
+RUN: git -C %t-s log --no-walk --format=%H r3                            \
+RUN:   | xargs %split2mono -C %t-s compute-mono %t.split2mono %t.svn2git \
+RUN:   | apply-commit-numbers %t.map | check-diff %s R3 %t
+R3: MUP-2
+RUN: git -C %t-s log --no-walk --format=%H r10                           \
+RUN:   | xargs %split2mono -C %t-s compute-mono %t.split2mono %t.svn2git \
+RUN:   | apply-commit-numbers %t.map | check-diff %s R10 %t
+R10: MUP-3
+RUN: git -C %t-s log --no-walk --format=%H downstream                        \
+RUN:   | xargs not %split2mono -C %t-s compute-mono %t.split2mono %t.svn2git \
+RUN:   | check-empty


### PR DESCRIPTION
This adds support for transparently remapping generated *split* commits
back to their original/canonical monorepo commits, if the split commits
have the right trailers.

Three trailers are required:

- `apple-llvm-monorepo-commit:` lists the monorepo commit to map back
  to.
- `apple-llvm-split-parents:` lists the expected parents for *this*
  commit.  These are checked against the actual parents in order to
  validate that we can trust the trailers at all; we don't want to
  confuse cherry-picks (which are new split commits) with the originals.
- `apple-llvm-upstream-merge-base:` is the upstream LLVM project
  monorepo commit that should be used as the "base" commit for untracked
  `dir` content.  If the upstream commit has an `llvm-svn:` trailer,
  that's used as the base rev; otherwise, a base rev is manufactured
  from the upstream commit's timestamp.