### PR TITLE
push: Fix branch name for llvm.org branches

### DIFF
--- a/git_apple_llvm/git_tools/push.py
+++ b/git_apple_llvm/git_tools/push.py
@@ -179,7 +179,7 @@ def isKnownTrackingBranch(remote: str, b: str) -> bool:
     remote_prefix = f'{remote}/'
     if not b.startswith(remote_prefix):
         return False
-    known_prefixes = set(['llvm', 'apple', 'internal', 'swift'])
+    known_prefixes = set(['llvm.org', 'apple', 'internal', 'swift'])
     return b[len(remote_prefix):].split('/')[0] in known_prefixes
 
 


### PR DESCRIPTION
Early on, we changed from `llvm/` to `llvm.org/` as a prefix for refs
forwarded from `github.com/llvm/llvm-project`.  Looks like
`git apple-llvm push` wasn't updated.