### PR TITLE
Make sure to export GIT_DIR in git-apple-llvm-fwd

### DIFF
--- a/libexec/apple-llvm/git-apple-llvm-fwd
+++ b/libexec/apple-llvm/git-apple-llvm-fwd
@@ -35,12 +35,8 @@ fwd_setup() {
 
     # Always change directory.
     log "Updating remotes up and syncing $GIT_DIR"
-    if [ -d "$GIT_DIR" ]; then
-        run --dry cd "$GIT_DIR" || error "failed to enter '$GIT_DIR'"
-    else
-        run --dry mkdir -p "$GIT_DIR" || error "failed to make '$GIT_DIR'"
+    run --hide-errors --dry git --git-dir="$GIT_DIR" show-ref >/dev/null ||
         run --dry git init || error "failed to create '$GIT_DIR'"
-    fi
 
     local -a remotes
     for remote in $(run cat "$FWD_CONFIG" |
@@ -98,6 +94,9 @@ while [ $# -gt 0 ]; do
 done
 
 [ -n "$NAME" ] || usage_error "missing name of fwd-config"
+
+# Export GIT_DIR so that child git processes use it
+export GIT_DIR
 
 fwd_setup || exit 1
 

--- a/test/fwd/master.test
+++ b/test/fwd/master.test
@@ -28,6 +28,10 @@ RUN: cat %s | sed -e s,__REPOS__,%t/repos, > %t/configs/t.fwd-config
 RUN: cd %t/working
 RUN: git apple-llvm fwd --config-dir %t/configs t
 
+# Check that we've put our working directory where we expected to
+RUN: git --git-dir %t/working/apple-llvm-fwd-repo.git show-ref
+RUN: not git --git-dir %t/working/.git show-ref
+
 # Check the output.
 RUN: git -C %t/repos/b.git show-ref a/master
 RUN: not git -C %t/repos/b.git show-ref refs/heads/master


### PR DESCRIPTION
This was setting GIT_DIR, but since it wasn't exported the git
commands would just create a git repo in the current directory
instead.