### PR TITLE
[git_tools] Make get_dev_null available from git_tools.

### DIFF
--- a/git_apple_llvm/git_tools/__init__.py
+++ b/git_apple_llvm/git_tools/__init__.py
@@ -3,11 +3,21 @@
 """
 
 from typing import Optional, List
-import subprocess
 import logging
+import os
 import shlex
+import subprocess
 
 log = logging.getLogger(__name__)
+dev_null_fd = None
+
+
+def get_dev_null():
+    """Lazily create a /dev/null fd for use in shell()"""
+    global dev_null_fd
+    if dev_null_fd is None:
+        dev_null_fd = open(os.devnull, 'w')
+    return dev_null_fd
 
 
 class GitError(Exception):

--- a/git_apple_llvm/git_tools/push.py
+++ b/git_apple_llvm/git_tools/push.py
@@ -12,6 +12,7 @@ from typing import Optional, List, Dict, Set
 from enum import Enum
 from contextlib import ExitStack
 from git_apple_llvm.git_tools import git, git_output, get_current_checkout_directory, commit_exists, GitError
+from git_apple_llvm.git_tools import get_dev_null
 
 
 # Global log.
@@ -272,17 +273,6 @@ class RegraftMissingSplitRootError(Exception):
 
     def __init__(self, root_commit_hash: str):
         self.root_commit_hash = root_commit_hash
-
-
-dev_null_fd = None
-
-
-def get_dev_null():
-    """Lazily create a /dev/null fd for use in shell()"""
-    global dev_null_fd
-    if dev_null_fd is None:
-        dev_null_fd = open(os.devnull, 'w')
-    return dev_null_fd
 
 
 def regraft_commit_graph_onto_split_repo(commit_graph: CommitGraph,


### PR DESCRIPTION
This is necessary to use get_dev_null from other places when using the
git function.