### PR TITLE
Show commit dates in the local timezone

### DIFF
--- a/git_apple_llvm/am/core.py
+++ b/git_apple_llvm/am/core.py
@@ -53,6 +53,7 @@ def compute_unmerged_commits(remote: str, target_branch: str,
     """ Returns the list of commits that are not yet merged from upstream to the target branch. """
     commit_log_output = git_output(
         'log',
+        '--date=local',
         '--first-parent',
         f'--pretty=format:{format}', '--no-patch',
         f'{remote}/{target_branch}..{remote}/{upstream_branch}',


### PR DESCRIPTION
This normalizes the dates and makes it more comprehensible.