### PR TITLE
Pin gitdb2 to version 2.0.6

### DIFF
--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,6 +1,7 @@
 pytest-mock
 pytest
 GitPython==2.1.11
+gitdb2==2.0.6
 lit
 flake8
 mypy


### PR DESCRIPTION
We have requirement for GitPython==2.1.11 which in turn requires GitDB.
There’s been a new version of GitDB and it has removed
`gitdb.utils.compat`. Since we pin GitPython to an older version, we’ll
have to pin GitDB to a corresponding working version too. Choosing 3.0.1
as that appears to be the last known working version.