### PR TITLE
Revert protocol.version=2-reliant patches (temporarily)

### DIFF
--- a/libexec/apple-llvm/git-apple-llvm-fwd
+++ b/libexec/apple-llvm/git-apple-llvm-fwd
@@ -88,18 +88,8 @@ fetch_remote() {
     # Don't fetch if this isn't a source.
     [ -n "$refs" ] || return 0
 
-    # Only negotiate with remote using refs from that remote; it's unlikely
-    # other remotes will speed anything up here.
-    #
-    # Note: Using show-ref to gather SHA-1s since early versions of Git don't
-    # accept patterns here.
-    local tips
-    tips="$(run --dry git for-each-ref \
-        --format="--negotiation-tip %(objectname)" "refs/remotes/$name/*")" ||
-        error "failed to iterate through remote tips of $name"
-
     log "    => fetching for $refs"
-    run --dry git fetch --prune "$name" $tips ||
+    run --dry git fetch --prune "$name" ||
         error "failed to fetch from '$name'"
 }
 

--- a/libexec/apple-llvm/git-apple-llvm-fwd
+++ b/libexec/apple-llvm/git-apple-llvm-fwd
@@ -38,9 +38,6 @@ fwd_setup() {
     run --hide-errors --dry git --git-dir="$GIT_DIR" show-ref >/dev/null ||
         run --dry git init --bare || error "failed to create '$GIT_DIR'"
 
-    # Configure protocol.
-    run --dry git config --local --replace-all protocol.version 2
-
     local -a remotes
     for remote in $(run cat "$FWD_CONFIG" |
         run awk '$1=="remote"{print $2 ":" $3}'); do

--- a/test/fwd/master.test
+++ b/test/fwd/master.test
@@ -32,11 +32,6 @@ RUN: git apple-llvm fwd --config-dir %t/configs t
 RUN: git --git-dir %t/working/apple-llvm-fwd-repo.git show-ref
 RUN: not git --git-dir %t/working/.git show-ref
 
-# Check the protocol version.
-RUN: git --git-dir %t/working/apple-llvm-fwd-repo.git config --local protocol.version \
-RUN: | check-diff %s PROTOCOL %t
-PROTOCOL: 2
-
 # Check the output.
 RUN: git -C %t/repos/b.git show-ref a/master
 RUN: not git -C %t/repos/b.git show-ref refs/heads/master


### PR DESCRIPTION
`protocol.version=2` requires Git v2.18.0+.  Temporarily revert a couple of patches until the bot is upgraded.