### PR TITLE
am-status: Always show number of unmerged commits in zippered merges

### DIFF
--- a/test/am/test_am_config.py
+++ b/test/am/test_am_config.py
@@ -78,14 +78,14 @@ def test_am_config(cd_to_am_tool_repo_clone):
 def test_am_print_status(cd_to_am_tool_repo_clone, capfd):
     print_status()
     captured = capfd.readouterr()
-    assert '[upstream -> master]\n- There are no unmerged commits. The master branch is up to date.\n' in captured.out
+    assert '[upstream -> master]\n- 0 unmerged commits. master is up to date.\n' in captured.out
 
 
 def test_am_status(cd_to_am_tool_repo_clone):
     result = CliRunner().invoke(am, ['status', '--target', 'master', '--no-fetch'])
 
     assert result.exit_code == 0
-    assert result.output == '[upstream -> master]\n- There are no unmerged commits. The master branch is up to date.\n'
+    assert result.output == '[upstream -> master]\n- 0 unmerged commits. master is up to date.\n'
 
 
 # FIXME: more tests.

--- a/test/am/test_secondary_edge_status.py
+++ b/test/am/test_secondary_edge_status.py
@@ -85,7 +85,9 @@ def test_am_secondary_edge_status(cd_to_am_tool_repo_clone):
     assert result.exit_code == 0
     assert """[downstream/master -> downstream/swift/master <- swift/master]
 - This is a zippered merge branch!
-- The automerger will perform at least one zippered merge on the next run.""" in result.output
+- 1 unmerged commits from downstream/master.
+- 2 unmerged commits from swift/master.
+- The automerger has found a common merge-base.""" in result.output
 
 
 def test_am_secondary_edge_status_merged(cd_to_am_tool_repo_clone):
@@ -94,7 +96,7 @@ def test_am_secondary_edge_status_merged(cd_to_am_tool_repo_clone):
     assert result.exit_code == 0
     assert """[downstream/master -> downstream/swift/master-merged <- swift/master]
 - This is a zippered merge branch!
-- There are no unmerged commits. The downstream/swift/master-merged branch is up to date.""" in result.output
+- 0 unmerged commits. downstream/swift/master-merged is up to date.""" in result.output
 
 
 def test_am_secondary_edge_status_blocked(cd_to_am_tool_repo_clone):
@@ -104,8 +106,8 @@ def test_am_secondary_edge_status_blocked(cd_to_am_tool_repo_clone):
     assert result.exit_code == 0
     assert """[downstream/master -> downstream/swift/master-unmergeable <- swift/master2]
 - This is a zippered merge branch!
-- There are 0 unmerged commits from downstream/master.
-- There are 1 unmerged commits from swift/master2.
-- The automerger is waiting for unmerged commits in
-  downstream/master and swift/master2 to agree on a merge base
-  from the master branch before performing a zippered merge.""" in result.output
+- 0 unmerged commits from downstream/master.
+- 1 unmerged commits from swift/master2.
+- The automerger is waiting for unmerged commits to share
+  a merge-base from master
+  before merging (i.e., one of the upstreams is behind).""" in result.output


### PR DESCRIPTION
Always show how many commits are waiting in zippered merge branches,
even when the automerger is unblocked.

As a drive-by, simplify some of the prose.