### PR TITLE
fwd: Allow forwarding master as-is

### DIFF
--- a/libexec/apple-llvm/git-apple-llvm-fwd
+++ b/libexec/apple-llvm/git-apple-llvm-fwd
@@ -53,6 +53,10 @@ fwd_setup() {
     run --hide-errors --dry git --git-dir="$GIT_DIR" show-ref >/dev/null ||
         run --dry git init --bare || error "failed to create '$GIT_DIR'"
 
+    # The local repo gets (ab)used as a remote.  Ensure we can delete all the
+    # branches in refs/heads/ (even if it happens to be refs/heads/master).
+    run --dry git config receive.denyDeleteCurrent ignore
+
     # Configure protocol.
     if check_git_version_at_least 2.18; then
         run --dry git config --local --replace-all protocol.version 2

--- a/test/fwd/master-as-master.test
+++ b/test/fwd/master-as-master.test
@@ -1,0 +1,47 @@
+remote a __REPOS__/a.git
+remote b __REPOS__/b.git
+
+push b refs/remotes/a/master:refs/heads/master
+
+# Clean up.
+RUN: rm -rf %t
+
+# Make repos and fill with data.
+RUN: mkdir -p %t/repos
+RUN: mkrepo --bare %t/repos/a.git
+RUN: mkrepo --bare %t/repos/b.git
+RUN: git clone %t/repos/a.git %t/a
+RUN: mkblob %t/a b1
+RUN: mkblob %t/a b2
+
+# Push and check.
+RUN: git -C %t/a push origin master
+RUN: git -C %t/repos/a.git show-ref master
+
+# Set up configs and run.
+RUN: mkdir -p %t/configs %t/working
+RUN: cat %s | sed -e s,__REPOS__,%t/repos, > %t/configs/t.fwd-config
+RUN: cd %t/working
+RUN: git apple-llvm fwd --config-dir %t/configs t
+
+# Check the output.
+RUN: git -C %t/repos/a.git show-ref master | awk '{print $1}' >%t/a.sha1
+RUN: git -C %t/repos/b.git show-ref master | awk '{print $1}' >%t/b.sha1
+RUN: diff %t/a.sha1 %t/b.sha1
+
+#######################################################
+# Check that running again only pushes if there's work.
+#######################################################
+
+# Move aside the destination remote.  If there's a push, it will fail.
+RUN: mv %t/repos/b.git %t/repos/b.git.backup
+
+# Try to forward.  There should be nothing to push, but detecting this requires
+# pruning the local repo's refs/head/master.  That could trigger an error if
+# we're not careful.
+RUN: cd %t/working
+RUN: git apple-llvm fwd --config-dir %t/configs t 2>&1 \
+RUN: | not grep "deletion of the current branch prohibited"
+
+# Move the destination remote back into place.
+RUN: mv %t/repos/b.git.backup %t/repos/b.git


### PR DESCRIPTION
Detecting whether there is anything to forward requires cleaning
out `refs/heads/*` and `refs/tags/*` from the local Git repo. This
uses a funky `git push` operation to allow globbed deletion, but
that means that Git is going to try to protect `refs/head/master`
from getting deleted.  Add a configuration to the local repo to
allow it to be deleted, since we don't actually care about it.