### PR TITLE
Revert "Use xcrun python3 for make test/docs if available"

### DIFF
--- a/make-helpers/python_venv_requirements.mk
+++ b/make-helpers/python_venv_requirements.mk
@@ -9,16 +9,6 @@ SETUP_PY_FILE=$(root_dir)/setup.py
 
 PYTHON_ROOT := $(VENV_OUT)/bin/
 
-ifeq (${shell which xcrun},)
-    XCRUN :=
-else
-    ifeq (${shell xcrun --find python3},)
-        XCRUN :=
-    else
-        XCRUN := xcrun
-    endif
-endif
-
 clean-venv:
 	rm -rf $(REQUIREMENTS_OUT) $(VENV_OUT)
 
@@ -26,7 +16,7 @@ venv: $(VENV_OUT) Makefile
 
 $(VENV_OUT):
 	@echo "Setting up python venv..."
-	$(XCRUN) python3 -m venv $(VENV_OUT)
+	python3 -m venv $(VENV_OUT)
 	@echo ""
 
 requirements: $(REQUIREMENTS_OUT) Makefile


### PR DESCRIPTION
This reverts commit 9bc189ea83cab1e74d78d2f97e4b123ee0a8e13d.

It is failing to compile the cffi module.
    c/_cffi_backend.c:5854:2: error: Apple Arm64 ABI requires ffi_prep_cif_var
    #error Apple Arm64 ABI requires ffi_prep_cif_var
     ^
    1 error generated.
    error: command 'xcrun' failed with exit status 1